### PR TITLE
[2022/12/02] - HomeScreenView CollectionView dataReload 구현 방식 수정 & HomeEditScreenView / jeonmmingu

### DIFF
--- a/NostelgiAlbum.xcodeproj/project.pbxproj
+++ b/NostelgiAlbum.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		8002F65328EE905B00E9913D /* HomeScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002F65228EE905B00E9913D /* HomeScreenViewController.swift */; };
 		8002F65528EE9D1800E9913D /* HomeScreenCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */; };
 		8020034B290FBB9200FCD54F /* AlbumScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8020034A290FBB9200FCD54F /* AlbumScreenViewController.swift */; };
+		806A653E293873C80054FAEF /* HomeEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806A653D293873C80054FAEF /* HomeEditViewController.swift */; };
 		807A193C29312CEF00BC434B /* RealmClassFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807A193B29312CEE00BC434B /* RealmClassFunc.swift */; };
 		807FF50129260656005D9884 /* InfoToolTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807FF50029260656005D9884 /* InfoToolTableViewCell.swift */; };
 		8094CA2428EDC65500E70F76 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8094CA2328EDC65500E70F76 /* AppDelegate.swift */; };
@@ -53,6 +54,7 @@
 		8002F65228EE905B00E9913D /* HomeScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenViewController.swift; sourceTree = "<group>"; };
 		8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenCollectionViewCell.swift; sourceTree = "<group>"; };
 		8020034A290FBB9200FCD54F /* AlbumScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumScreenViewController.swift; sourceTree = "<group>"; };
+		806A653D293873C80054FAEF /* HomeEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeEditViewController.swift; sourceTree = "<group>"; };
 		807A193B29312CEE00BC434B /* RealmClassFunc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmClassFunc.swift; sourceTree = "<group>"; };
 		807FF50029260656005D9884 /* InfoToolTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoToolTableViewCell.swift; sourceTree = "<group>"; };
 		8094CA2028EDC65500E70F76 /* NostelgiAlbum.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NostelgiAlbum.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -149,6 +151,7 @@
 				8094CA2528EDC65500E70F76 /* SceneDelegate.swift */,
 				8002F65228EE905B00E9913D /* HomeScreenViewController.swift */,
 				8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */,
+				806A653D293873C80054FAEF /* HomeEditViewController.swift */,
 				8020034A290FBB9200FCD54F /* AlbumScreenViewController.swift */,
 				80DF50AD290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift */,
 				8312C9D42921482A00556BAE /* SearchToolViewController.swift */,
@@ -434,6 +437,7 @@
 				8094CA2428EDC65500E70F76 /* AppDelegate.swift in Sources */,
 				80DF50AE290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift in Sources */,
 				8312C9D32921465600556BAE /* InfoToolViewController.swift in Sources */,
+				806A653E293873C80054FAEF /* HomeEditViewController.swift in Sources */,
 				8094CA2628EDC65500E70F76 /* SceneDelegate.swift in Sources */,
 				807A193C29312CEF00BC434B /* RealmClassFunc.swift in Sources */,
 				8312C9D52921482A00556BAE /* SearchToolViewController.swift in Sources */,

--- a/NostelgiAlbum/Base.lproj/Main.storyboard
+++ b/NostelgiAlbum/Base.lproj/Main.storyboard
@@ -14,12 +14,12 @@
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController storyboardIdentifier="HomeScreenViewController" id="BYZ-38-t0r" customClass="HomeScreenViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="8bC-Xf-vdC">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="INu-ib-KxC">
-                                <rect key="frame" x="0.0" y="103" width="390" height="522"/>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="INu-ib-KxC">
+                                <rect key="frame" x="0.0" y="103" width="393" height="522"/>
                                 <color key="backgroundColor" red="0.40000003579999999" green="0.2901961207" blue="0.231372565" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="390" id="DQn-zg-iMi"/>
@@ -33,7 +33,7 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeScreenCollectionViewCell" id="Xdi-Mm-CLH" customClass="HomeScreenCollectionViewCell" customModule="NostelgiAlbum" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="191"/>
+                                        <rect key="frame" x="1.6666666666666667" y="0.0" width="390" height="191"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="n9d-vr-h7a">
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="191"/>
@@ -134,8 +134,8 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="NostelgiAlbum" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FCk-00-G7W">
-                                <rect key="frame" x="0.0" y="625" width="390" height="193"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NostelgiAlbum" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FCk-00-G7W">
+                                <rect key="frame" x="0.0" y="625" width="393" height="193"/>
                                 <color key="backgroundColor" red="0.40000000000000002" green="0.2901960784" blue="0.23137254900000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="193" id="QB1-rU-mDA"/>
@@ -146,7 +146,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lwh-i1-Wmq">
-                                <rect key="frame" x="0.0" y="97" width="390" height="7"/>
+                                <rect key="frame" x="0.0" y="97" width="393" height="7"/>
                                 <color key="backgroundColor" red="0.23497083760000001" green="0.17027528459999999" blue="0.1365594789" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="7" id="6hO-ES-XHi"/>
@@ -309,11 +309,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view alpha="0.69999999999999996" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1ch-VZ-qWX">
-                                <rect key="frame" x="0.0" y="40" width="390" height="763"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </view>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bBD-hI-lpc">
                                 <rect key="frame" x="34" y="340" width="321" height="164"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -352,8 +347,18 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
+                            <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1ch-VZ-qWX">
+                                <rect key="frame" x="3" y="59" width="390" height="763"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="5HT-oa-Gx4"/>
+                        <constraints>
+                            <constraint firstItem="1ch-VZ-qWX" firstAttribute="bottom" secondItem="5HT-oa-Gx4" secondAttribute="bottom" constant="4" id="63M-mQ-rTf"/>
+                            <constraint firstItem="5HT-oa-Gx4" firstAttribute="trailing" secondItem="1ch-VZ-qWX" secondAttribute="trailing" id="Mfs-Ag-gu2"/>
+                            <constraint firstItem="1ch-VZ-qWX" firstAttribute="top" secondItem="5HT-oa-Gx4" secondAttribute="top" id="O8F-76-LSs"/>
+                            <constraint firstItem="1ch-VZ-qWX" firstAttribute="leading" secondItem="5HT-oa-Gx4" secondAttribute="leading" constant="3" id="nJr-Zz-D68"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="popupView" destination="bBD-hI-lpc" id="89G-sE-yKS"/>
@@ -445,6 +450,108 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aNF-3u-l0V" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1244.6153846153845" y="1638.6255924170616"/>
+        </scene>
+        <!--Home Edit View Controller-->
+        <scene sceneID="0aW-w8-X60">
+            <objects>
+                <viewController storyboardIdentifier="HomeEditViewController" id="uG1-g0-tif" customClass="HomeEditViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="W9P-Ih-jmQ">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view alpha="0.75" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kBP-fR-9mu">
+                                <rect key="frame" x="0.0" y="40" width="390" height="763"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sRN-Fp-mgI">
+                                <rect key="frame" x="36" y="234" width="321" height="384"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="New Album" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GMa-bZ-V1a">
+                                        <rect key="frame" x="116" y="32" width="88" height="21"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W6f-sn-2kD">
+                                        <rect key="frame" x="23" y="98" width="36" height="16"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Image" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2L7-YO-vhA">
+                                        <rect key="frame" x="23" y="143" width="37" height="16"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JHW-5g-6Ba">
+                                        <rect key="frame" x="76" y="89" width="199" height="34"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RWd-Le-Twy">
+                                        <rect key="frame" x="239" y="134" width="36" height="34"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="filled" title="+">
+                                            <fontDescription key="titleFontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="13"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="addImage:" destination="uG1-g0-tif" eventType="touchUpInside" id="iRA-e5-qZV"/>
+                                        </connections>
+                                    </button>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SgP-uG-7mx">
+                                        <rect key="frame" x="78" y="134" width="153" height="146"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    </imageView>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eDh-hN-cDJ">
+                                        <rect key="frame" x="78" y="313" width="59" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="save"/>
+                                        <connections>
+                                            <action selector="closeButton:" destination="kMX-HM-r06" eventType="touchUpInside" id="RAW-fL-GE6"/>
+                                            <action selector="saveAlbum:" destination="uG1-g0-tif" eventType="touchUpInside" id="cnL-cV-Axg"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Im-bq-rgU">
+                                        <rect key="frame" x="178" y="313" width="65" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="close"/>
+                                        <connections>
+                                            <action selector="closeButton:" destination="uG1-g0-tif" eventType="touchUpInside" id="R9r-kr-I9v"/>
+                                            <action selector="closeButton:" destination="kMX-HM-r06" eventType="touchUpInside" id="gob-4Y-Lft"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="5O0-EV-K1R"/>
+                        <constraints>
+                            <constraint firstItem="5O0-EV-K1R" firstAttribute="trailing" secondItem="kBP-fR-9mu" secondAttribute="trailing" constant="3" id="Or0-yO-xBp"/>
+                            <constraint firstItem="kBP-fR-9mu" firstAttribute="leading" secondItem="5O0-EV-K1R" secondAttribute="leading" id="VIP-EY-1p9"/>
+                            <constraint firstItem="5O0-EV-K1R" firstAttribute="top" secondItem="kBP-fR-9mu" secondAttribute="top" constant="19" id="uZ7-pd-Dc9"/>
+                            <constraint firstItem="kBP-fR-9mu" firstAttribute="bottom" secondItem="5O0-EV-K1R" secondAttribute="bottom" constant="34" id="yj3-aA-Qo3"/>
+                        </constraints>
+                    </view>
+                    <toolbarItems/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="albumName" destination="JHW-5g-6Ba" id="pF0-0T-KRf"/>
+                        <outlet property="coverImage" destination="SgP-uG-7mx" id="tHP-im-e3V"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="82C-Jj-OyW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-579.38931297709917" y="1637.323943661972"/>
         </scene>
     </scenes>
     <resources>

--- a/NostelgiAlbum/HomeEditViewController.swift
+++ b/NostelgiAlbum/HomeEditViewController.swift
@@ -1,0 +1,59 @@
+//
+//  HomeEditViewController.swift
+//  NostelgiAlbum
+//
+//  Created by 전민구 on 2022/12/01.
+//
+
+import UIKit
+
+class HomeEditViewController: UIViewController {
+    
+    let picker = UIImagePickerController()
+    @IBOutlet weak var albumName: UITextField!
+    @IBOutlet weak var coverImage: UIImageView!
+    
+    override func viewDidLoad(){
+        super.viewDidLoad()
+        picker.delegate = self
+    }
+    
+    @IBAction func saveAlbum(_ sender: Any) {
+        // save album info in realm DB
+    }
+    
+    @IBAction func closeButton(_ sender: Any) {
+        dismiss(animated: false, completion: nil)
+    }
+    
+    @IBAction func addImage(_ sender: Any) {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let library = UIAlertAction(title: "사진 앨범", style: .default){(action) in self.openLibrary()}
+        let camera = UIAlertAction(title: "카매라", style: .default){(action) in self.openCamera()}
+        let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        alert.addAction(library)
+        alert.addAction(camera)
+        alert.addAction(cancel)
+        present(alert, animated: true, completion: nil)
+    }
+    
+    func openLibrary(){
+        picker.sourceType = .photoLibrary
+        present(picker, animated: false, completion: nil)
+    }
+    
+    func openCamera(){
+        picker.sourceType = .camera
+        present(picker, animated: false, completion: nil)
+    }
+}
+
+extension HomeEditViewController : UINavigationControllerDelegate, UIImagePickerControllerDelegate{
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage{
+                    coverImage.image = image
+                }
+        dismiss(animated: true, completion: nil)
+    }
+}

--- a/NostelgiAlbum/HomeScreenViewController.swift
+++ b/NostelgiAlbum/HomeScreenViewController.swift
@@ -15,13 +15,15 @@ class HomeScreenViewController: UIViewController {
     // collectionView setting
     @IBOutlet weak var collectionView: UICollectionView!
     
-    var order:Int = 0
-    var row:Int = 0
     var image: UIImage?
     var count:Int = 0
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        print(Realm.Configuration.defaultConfiguration.fileURL!)
+//        try! realm.write{
+//            realm.deleteAll()
+//        }
 //        setAlbum()
 //        setAlbumCover()
         collectionView.dataSource = self
@@ -42,7 +44,12 @@ class HomeScreenViewController: UIViewController {
 extension HomeScreenViewController: UICollectionViewDataSource{
     // Collection View 안에 셀을 몇개로 구성할 것인지
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return self.row + 1
+        let cover_num = realm.objects(albumCover.self).count + 1
+        // 앨범의 개수를 6개로 제한
+        if cover_num == 7{
+            return 3
+        }
+        return cover_num % 2 == 0 ? cover_num/2 : cover_num/2 + 1
     }
     
     // 셀을 어떻게 표현할 것인지 (Presentation)
@@ -50,62 +57,62 @@ extension HomeScreenViewController: UICollectionViewDataSource{
         // 만들어 놓은 ReusableCell 중에 사용할 셀을 고르는 부분
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "HomeScreenCollectionViewCell", for: indexPath) as! HomeScreenCollectionViewCell
         
-        let firstbuttonInfo : albumCover?
-        let secondbuttonInfo : albumCover?
-        firstbuttonInfo = realm.objects(albumCover.self).filter("id = \(indexPath.row * 2 + 1)").first
-        secondbuttonInfo = realm.objects(albumCover.self).filter("id = \(indexPath.row * 2 + 2)").first
-        
-        if firstbuttonInfo != nil{
-            image = UIImage(named: firstbuttonInfo!.coverImageName)
-            cell.firstButton.setImage(image, for: .normal)
-            cell.firstButton.setTitle(firstbuttonInfo!.albumName, for: .normal)
+        let cover_num = realm.objects(albumCover.self).count + 1
+        if (indexPath.row + 1) * 2 <= cover_num{
+            cell.firstButton.isHidden = false
+            cell.firstButton.isHidden = false
+            let firstbuttonInfo : albumCover?
+            let secondbuttonInfo : albumCover?
+            firstbuttonInfo = realm.objects(albumCover.self).filter("id = \(indexPath.row * 2 + 1)").first
+            secondbuttonInfo = realm.objects(albumCover.self).filter("id = \(indexPath.row * 2 + 2)").first
+            if firstbuttonInfo != nil{
+                image = UIImage(named: firstbuttonInfo!.coverImageName)
+                cell.firstButton.setImage(image, for: .normal)
+                cell.firstButton.setTitle(firstbuttonInfo!.albumName, for: .normal)
+            }
+            if secondbuttonInfo != nil{
+                image = UIImage(named: secondbuttonInfo!.coverImageName)
+                cell.secondButton.setImage(image, for: .normal)
+                cell.secondButton.setTitle(secondbuttonInfo!.albumName, for: .normal)
+            }
         }
-        if secondbuttonInfo != nil{
-            image = UIImage(named: secondbuttonInfo!.coverImageName)
-            cell.secondButton.setImage(image, for: .normal)
-            cell.secondButton.setTitle(secondbuttonInfo!.albumName, for: .normal)
-        }
-        
-        
-        // 1번째 인자 빼고 전부 hidden state
-        if indexPath.row != 0 || self.order != 0{
-            cell.firstButton.isHidden = true
+        else if (indexPath.row + 1) * 2 - 1 == cover_num{
+            cell.firstButton.isHidden = false
             cell.secondButton.isHidden = true
         }
         else{
+            cell.firstButton.isHidden = true
             cell.secondButton.isHidden = true
-        }
-
-        // 하나씩 해제 되는 코드
-        if indexPath.row < self.row{
-            cell.firstButton.isHidden = false
-            cell.secondButton.isHidden = false
-        }
-        else if indexPath.row == self.row{
-            if self.order == 0{
-                cell.firstButton.isHidden = false
-            }
-            else {
-                cell.firstButton.isHidden = false
-                cell.secondButton.isHidden = false
-            }
         }
         
         cell.callback1={
-            guard let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "AlbumScreenViewController") as? AlbumScreenViewController else{ return }
-            pushVC.pageNum = 0
-            self.order = self.order + 1
-            self.collectionView.reloadData()
-            self.navigationController?.pushViewController(pushVC, animated: false)
+            if cell.firstButton.titleLabel!.text == "+"{
+                guard let editVC = self.storyboard?.instantiateViewController(withIdentifier: "HomeEditViewController") as? HomeEditViewController else{ return }
+                editVC.modalPresentationStyle = .overCurrentContext
+                self.present(editVC, animated: false)
+                self.collectionView.setNeedsDisplay()
+            }
+            else{
+                guard let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "AlbumScreenViewController") as? AlbumScreenViewController else{ return }
+                pushVC.pageNum = 0
+                pushVC.coverIndex = indexPath.row * 2
+                self.navigationController?.pushViewController(pushVC, animated: false)
+            }
         }
         
         cell.callback2={
-            guard let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "AlbumScreenViewController") as? AlbumScreenViewController else{ return }
-            pushVC.pageNum = 0
-            self.order = self.order - 1
-            self.row = self.row + 1
-            self.collectionView.reloadData()
-            self.navigationController?.pushViewController(pushVC, animated: false)
+            if cell.secondButton.titleLabel!.text == "+"{
+                guard let editVC = self.storyboard?.instantiateViewController(withIdentifier: "HomeEditViewController") as? HomeEditViewController else{ return }
+                editVC.modalPresentationStyle = .overCurrentContext
+                self.present(editVC, animated: false)
+                self.collectionView.setNeedsDisplay()
+            }
+            else{
+                guard let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "AlbumScreenViewController") as? AlbumScreenViewController else{ return }
+                pushVC.pageNum = 0
+                pushVC.coverIndex = indexPath.row * 2 + 1
+                self.navigationController?.pushViewController(pushVC, animated: false)
+            }
         }
         return cell
     }

--- a/NostelgiAlbum/Info.plist
+++ b/NostelgiAlbum/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>test</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>test</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/NostelgiAlbum/RealmClassFunc.swift
+++ b/NostelgiAlbum/RealmClassFunc.swift
@@ -9,7 +9,6 @@ import Foundation
 import RealmSwift
 
 class album : Object{
-    @objc dynamic var id : Int = 0
     @objc dynamic var index : Int = 0
     @objc dynamic var ImageName : String = ""
     @objc dynamic var ImageText : String = ""
@@ -23,16 +22,6 @@ class album : Object{
     func setImageText(_ db : String){
         ImageText = db
     }
-    
-    override static func primaryKey() -> String? {
-          return "id"
-    }
-    
-    func incrementIndex(){
-        let realm = try! Realm()
-        id = (realm.objects(album.self).max(ofProperty: "id") as Int? ?? 0) + 1
-    }
-    
 }
 
 class albumCover : Object{
@@ -106,22 +95,18 @@ func setAlbum(){
         }
     }
 
-    Add_album1.incrementIndex()
     Add_album1.setIndex(0)
     Add_album1.setImageName("지웅")
     Add_album1.setImageText("바닷가에서 폼 잡고 있는 지웅이")
     Realm_write(Add_album1)
-    Add_album2.incrementIndex()
     Add_album2.setIndex(0)
     Add_album2.setImageName("경범")
     Add_album2.setImageText("폼 잡고 있는 경범이 형")
     Realm_write(Add_album2)
-    Add_album3.incrementIndex()
     Add_album3.setIndex(0)
     Add_album3.setImageName("민구")
     Add_album3.setImageText("그냥 민구")
     Realm_write(Add_album3)
-    Add_album4.incrementIndex()
     Add_album4.setIndex(0)
     Add_album4.setImageName("철수")
     Add_album4.setImageText("늠름한 고양이 철수")

--- a/NostelgiAlbum/SearchToolViewController.swift
+++ b/NostelgiAlbum/SearchToolViewController.swift
@@ -16,6 +16,8 @@ class SearchToolViewController: UIViewController {
     
     @IBOutlet weak var popupView: UIView!
     @IBOutlet weak var searchText: UITextField!
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         popupView.layer.cornerRadius = 6
@@ -24,6 +26,7 @@ class SearchToolViewController: UIViewController {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
     }
+    
     @IBAction func closeButton(_ sender: Any) {
         dismiss(animated: false, completion: nil)
     }


### PR DESCRIPTION
## 작성 내용
1. AlbumScreenViewController coverIndex 추가 : 몇 번째 앨범인지 체크하기 위해
2. HomeScreenViewController dataReload해서 앨범 해제 구현한 부분 -> DB albumCover 개수로 구현
3. HomeEditViewController 추가 : HomeScreen에서 앨범을 추가할 수 있는 항목

## 특이사항
1. info.plist 에서 핸드폰의 album document 에 접근할 수 있는 권한 설정
2. RealmClassFunc - Class album에서 primary key : var i -> 삭제
3. HomeEditViewController saveButton 부분은 아직 구현 못함 (사진 저장은 copy 방식으로 진행 예정)
