### PR TITLE
[2023/02/09]-AlbumSharing기능구현/chopmozzi

### DIFF
--- a/NostelgiAlbum.xcodeproj/project.pbxproj
+++ b/NostelgiAlbum.xcodeproj/project.pbxproj
@@ -7,8 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		44989FA2FA524E8EEEBA60C5 /* Pods_NostelgiAlbumTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 401EAAE9DE0F626378A73BD5 /* Pods_NostelgiAlbumTests.framework */; };
-		542A5706277B9EFA322C469D /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A37BCC6121739C6133FF1DE6 /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework */; };
+		6E40494444D284B57AB22A17 /* Pods_NostelgiAlbumTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD45D2E351EE192C1D87DB8D /* Pods_NostelgiAlbumTests.framework */; };
 		8002F65328EE905B00E9913D /* HomeScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002F65228EE905B00E9913D /* HomeScreenViewController.swift */; };
 		8002F65528EE9D1800E9913D /* HomeScreenCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */; };
 		8020034B290FBB9200FCD54F /* AlbumScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8020034A290FBB9200FCD54F /* AlbumScreenViewController.swift */; };
@@ -36,7 +35,10 @@
 		83C615C8298B978D0018BBAF /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615C7298B978D0018BBAF /* ShareViewController.swift */; };
 		83C615CA298BA3C90018BBAF /* UTI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615C9298BA3C90018BBAF /* UTI.swift */; };
 		83C615F1298EBB010018BBAF /* SharingAlbumPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615F0298EBB010018BBAF /* SharingAlbumPush.swift */; };
-		9637805CE99D7E121BEE0717 /* Pods_NostelgiAlbum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A0A83F13AEEA742D0FD55A4 /* Pods_NostelgiAlbum.framework */; };
+		83C615F4299942FD0018BBAF /* ShareFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615F3299942FD0018BBAF /* ShareFunc.swift */; };
+		83C615F629994CE30018BBAF /* ToolBarButtonAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615F529994CE30018BBAF /* ToolBarButtonAction.swift */; };
+		C0F3ECE166A7DAA34C483BBF /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9012CEB3A508CA15AB036C93 /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework */; };
+		C674A76DE71B2D6B321B1C1E /* Pods_NostelgiAlbum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 333B1EB0131BF7D37399E3F7 /* Pods_NostelgiAlbum.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,10 +59,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		3799B6D3405FAB35D79C7103 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum-NostelgiAlbumUITests/Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig"; sourceTree = "<group>"; };
-		3A0A83F13AEEA742D0FD55A4 /* Pods_NostelgiAlbum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NostelgiAlbum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		401EAAE9DE0F626378A73BD5 /* Pods_NostelgiAlbumTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NostelgiAlbumTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		66A42BFB3D9C5A9D8D866E41 /* Pods-NostelgiAlbum.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum.debug.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum.debug.xcconfig"; sourceTree = "<group>"; };
+		09E86ACB70C1454B76E222B5 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum-NostelgiAlbumUITests/Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		333B1EB0131BF7D37399E3F7 /* Pods_NostelgiAlbum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NostelgiAlbum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C8290A5F6ED840AD5B917C9 /* Pods-NostelgiAlbum.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum.debug.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum.debug.xcconfig"; sourceTree = "<group>"; };
+		6601033F99ABB4CE0338C61C /* Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum-NostelgiAlbumUITests/Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig"; sourceTree = "<group>"; };
+		6E5DCC93F7BDA1B362378A7C /* Pods-NostelgiAlbum.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum.release.xcconfig"; sourceTree = "<group>"; };
 		8002F65228EE905B00E9913D /* HomeScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenViewController.swift; sourceTree = "<group>"; };
 		8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenCollectionViewCell.swift; sourceTree = "<group>"; };
 		8020034A290FBB9200FCD54F /* AlbumScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumScreenViewController.swift; sourceTree = "<group>"; };
@@ -92,11 +95,12 @@
 		83C615C7298B978D0018BBAF /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		83C615C9298BA3C90018BBAF /* UTI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTI.swift; sourceTree = "<group>"; };
 		83C615F0298EBB010018BBAF /* SharingAlbumPush.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingAlbumPush.swift; sourceTree = "<group>"; };
-		884CF07808E0B766753C3292 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum-NostelgiAlbumUITests/Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		8FFC13E4AFBFFF078784A65D /* Pods-NostelgiAlbum.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum.release.xcconfig"; sourceTree = "<group>"; };
-		A37BCC6121739C6133FF1DE6 /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NostelgiAlbum_NostelgiAlbumUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C3EC5C868D5280CF9D73AB4D /* Pods-NostelgiAlbumTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbumTests.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbumTests/Pods-NostelgiAlbumTests.release.xcconfig"; sourceTree = "<group>"; };
-		F00B25CE38D4EB515594CCC9 /* Pods-NostelgiAlbumTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbumTests.debug.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbumTests/Pods-NostelgiAlbumTests.debug.xcconfig"; sourceTree = "<group>"; };
+		83C615F3299942FD0018BBAF /* ShareFunc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShareFunc.swift; path = ../../../ShareFunc.swift; sourceTree = "<group>"; };
+		83C615F529994CE30018BBAF /* ToolBarButtonAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBarButtonAction.swift; sourceTree = "<group>"; };
+		9012CEB3A508CA15AB036C93 /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NostelgiAlbum_NostelgiAlbumUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		91F58AEC0D6B332A167C129D /* Pods-NostelgiAlbumTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbumTests.debug.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbumTests/Pods-NostelgiAlbumTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D8BEDED1B5046A84DA5ED8E9 /* Pods-NostelgiAlbumTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbumTests.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbumTests/Pods-NostelgiAlbumTests.release.xcconfig"; sourceTree = "<group>"; };
+		DD45D2E351EE192C1D87DB8D /* Pods_NostelgiAlbumTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NostelgiAlbumTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,7 +108,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9637805CE99D7E121BEE0717 /* Pods_NostelgiAlbum.framework in Frameworks */,
+				C674A76DE71B2D6B321B1C1E /* Pods_NostelgiAlbum.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,7 +116,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				44989FA2FA524E8EEEBA60C5 /* Pods_NostelgiAlbumTests.framework in Frameworks */,
+				6E40494444D284B57AB22A17 /* Pods_NostelgiAlbumTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,7 +124,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				542A5706277B9EFA322C469D /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework in Frameworks */,
+				C0F3ECE166A7DAA34C483BBF /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -130,12 +134,12 @@
 		6C221F8D594D7C5B1A9DAF84 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				66A42BFB3D9C5A9D8D866E41 /* Pods-NostelgiAlbum.debug.xcconfig */,
-				8FFC13E4AFBFFF078784A65D /* Pods-NostelgiAlbum.release.xcconfig */,
-				884CF07808E0B766753C3292 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig */,
-				3799B6D3405FAB35D79C7103 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig */,
-				F00B25CE38D4EB515594CCC9 /* Pods-NostelgiAlbumTests.debug.xcconfig */,
-				C3EC5C868D5280CF9D73AB4D /* Pods-NostelgiAlbumTests.release.xcconfig */,
+				4C8290A5F6ED840AD5B917C9 /* Pods-NostelgiAlbum.debug.xcconfig */,
+				6E5DCC93F7BDA1B362378A7C /* Pods-NostelgiAlbum.release.xcconfig */,
+				09E86ACB70C1454B76E222B5 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig */,
+				6601033F99ABB4CE0338C61C /* Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig */,
+				91F58AEC0D6B332A167C129D /* Pods-NostelgiAlbumTests.debug.xcconfig */,
+				D8BEDED1B5046A84DA5ED8E9 /* Pods-NostelgiAlbumTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -148,7 +152,7 @@
 				8094CA4328EDC65900E70F76 /* NostelgiAlbumUITests */,
 				8094CA2128EDC65500E70F76 /* Products */,
 				6C221F8D594D7C5B1A9DAF84 /* Pods */,
-				BC1760A270AA912477243107 /* Frameworks */,
+				FECECB9A8ECAB2BAC00F6319 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -174,6 +178,7 @@
 				831A0520297A9B7A009D26A0 /* HomeScreenViewController */,
 				831A0522297A9BD7009D26A0 /* AlbumScreenViewController */,
 				831A0524297A9BF3009D26A0 /* ToolBarController */,
+				83C615F2299942BE0018BBAF /* ShareFunc */,
 				831A0525297A9BFE009D26A0 /* ImageFunc */,
 				8094CA2C28EDC65900E70F76 /* Assets.xcassets */,
 				8094CA3128EDC65900E70F76 /* Info.plist */,
@@ -214,8 +219,8 @@
 				80C56D17298CE5360063688F /* HomeScreenViewController+CollectionView.swift */,
 				8092C3A4298CF1AA007FFEF3 /* CollectionView+ButtonAction.swift */,
 				8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */,
-				831A0521297A9BCA009D26A0 /* HomeDetailController */,
 				83C615F0298EBB010018BBAF /* SharingAlbumPush.swift */,
+				831A0521297A9BCA009D26A0 /* HomeDetailController */,
 			);
 			path = HomeScreenViewController;
 			sourceTree = "<group>";
@@ -234,6 +239,7 @@
 			children = (
 				8020034A290FBB9200FCD54F /* AlbumScreenViewController.swift */,
 				80DF50AD290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift */,
+				83C615F529994CE30018BBAF /* ToolBarButtonAction.swift */,
 				831A0523297A9BE7009D26A0 /* AlbumDetailController */,
 			);
 			path = AlbumScreenViewController;
@@ -267,12 +273,20 @@
 			path = ImageFunc;
 			sourceTree = "<group>";
 		};
-		BC1760A270AA912477243107 /* Frameworks */ = {
+		83C615F2299942BE0018BBAF /* ShareFunc */ = {
 			isa = PBXGroup;
 			children = (
-				3A0A83F13AEEA742D0FD55A4 /* Pods_NostelgiAlbum.framework */,
-				A37BCC6121739C6133FF1DE6 /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework */,
-				401EAAE9DE0F626378A73BD5 /* Pods_NostelgiAlbumTests.framework */,
+				83C615F3299942FD0018BBAF /* ShareFunc.swift */,
+			);
+			path = ShareFunc;
+			sourceTree = "<group>";
+		};
+		FECECB9A8ECAB2BAC00F6319 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				333B1EB0131BF7D37399E3F7 /* Pods_NostelgiAlbum.framework */,
+				9012CEB3A508CA15AB036C93 /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework */,
+				DD45D2E351EE192C1D87DB8D /* Pods_NostelgiAlbumTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -284,11 +298,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8094CA4A28EDC65900E70F76 /* Build configuration list for PBXNativeTarget "NostelgiAlbum" */;
 			buildPhases = (
-				0C1D3E204F137C9DAD707FC0 /* [CP] Check Pods Manifest.lock */,
+				E28A8C0DE1DF1C1F91F8B84A /* [CP] Check Pods Manifest.lock */,
 				8094CA1C28EDC65500E70F76 /* Sources */,
 				8094CA1D28EDC65500E70F76 /* Frameworks */,
 				8094CA1E28EDC65500E70F76 /* Resources */,
-				AF0FC730FDFF0EA6954C6804 /* [CP] Embed Pods Frameworks */,
+				1CD8F48525C514C013D1C903 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -303,7 +317,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8094CA4D28EDC65900E70F76 /* Build configuration list for PBXNativeTarget "NostelgiAlbumTests" */;
 			buildPhases = (
-				1A2695FEED75E88CF2021763 /* [CP] Check Pods Manifest.lock */,
+				A48282DD6F50277915745ADE /* [CP] Check Pods Manifest.lock */,
 				8094CA3228EDC65900E70F76 /* Sources */,
 				8094CA3328EDC65900E70F76 /* Frameworks */,
 				8094CA3428EDC65900E70F76 /* Resources */,
@@ -322,11 +336,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8094CA5028EDC65900E70F76 /* Build configuration list for PBXNativeTarget "NostelgiAlbumUITests" */;
 			buildPhases = (
-				20250F3BB5A97ABDA4FF558A /* [CP] Check Pods Manifest.lock */,
+				A52AF3AC3F19CDEA0795F10D /* [CP] Check Pods Manifest.lock */,
 				8094CA3C28EDC65900E70F76 /* Sources */,
 				8094CA3D28EDC65900E70F76 /* Frameworks */,
 				8094CA3E28EDC65900E70F76 /* Resources */,
-				5111E9E2C4073E03F647D7EC /* [CP] Embed Pods Frameworks */,
+				EB227F7EB62AD22DD1C38D29 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -409,29 +423,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0C1D3E204F137C9DAD707FC0 /* [CP] Check Pods Manifest.lock */ = {
+		1CD8F48525C514C013D1C903 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
+			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NostelgiAlbum-checkManifestLockResult.txt",
+				"${PODS_ROOT}/Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1A2695FEED75E88CF2021763 /* [CP] Check Pods Manifest.lock */ = {
+		A48282DD6F50277915745ADE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -453,7 +462,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		20250F3BB5A97ABDA4FF558A /* [CP] Check Pods Manifest.lock */ = {
+		A52AF3AC3F19CDEA0795F10D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -475,7 +484,29 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5111E9E2C4073E03F647D7EC /* [CP] Embed Pods Frameworks */ = {
+		E28A8C0DE1DF1C1F91F8B84A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-NostelgiAlbum-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EB227F7EB62AD22DD1C38D29 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -490,23 +521,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NostelgiAlbum-NostelgiAlbumUITests/Pods-NostelgiAlbum-NostelgiAlbumUITests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AF0FC730FDFF0EA6954C6804 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -531,9 +545,11 @@
 				831A04DA295EC04C009D26A0 /* ImageViewController.swift in Sources */,
 				80DF50AE290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift in Sources */,
 				8312C9D32921465600556BAE /* InfoToolViewController.swift in Sources */,
+				83C615F4299942FD0018BBAF /* ShareFunc.swift in Sources */,
 				806A653E293873C80054FAEF /* HomeEditViewController.swift in Sources */,
 				8320291F295EA8E2001709E9 /* AlbumEditViewController.swift in Sources */,
 				8092C3A3298CE6F0007FFEF3 /* HomeEditViewController+ButtonAction.swift in Sources */,
+				83C615F629994CE30018BBAF /* ToolBarButtonAction.swift in Sources */,
 				8094CA2628EDC65500E70F76 /* SceneDelegate.swift in Sources */,
 				807A193C29312CEF00BC434B /* RealmClassFunc.swift in Sources */,
 				8312C9D52921482A00556BAE /* SearchToolViewController.swift in Sources */,
@@ -708,7 +724,7 @@
 		};
 		8094CA4B28EDC65900E70F76 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 66A42BFB3D9C5A9D8D866E41 /* Pods-NostelgiAlbum.debug.xcconfig */;
+			baseConfigurationReference = 4C8290A5F6ED840AD5B917C9 /* Pods-NostelgiAlbum.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -739,7 +755,7 @@
 		};
 		8094CA4C28EDC65900E70F76 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8FFC13E4AFBFFF078784A65D /* Pods-NostelgiAlbum.release.xcconfig */;
+			baseConfigurationReference = 6E5DCC93F7BDA1B362378A7C /* Pods-NostelgiAlbum.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -770,7 +786,7 @@
 		};
 		8094CA4E28EDC65900E70F76 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F00B25CE38D4EB515594CCC9 /* Pods-NostelgiAlbumTests.debug.xcconfig */;
+			baseConfigurationReference = 91F58AEC0D6B332A167C129D /* Pods-NostelgiAlbumTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -791,7 +807,7 @@
 		};
 		8094CA4F28EDC65900E70F76 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C3EC5C868D5280CF9D73AB4D /* Pods-NostelgiAlbumTests.release.xcconfig */;
+			baseConfigurationReference = D8BEDED1B5046A84DA5ED8E9 /* Pods-NostelgiAlbumTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -812,7 +828,7 @@
 		};
 		8094CA5128EDC65900E70F76 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 884CF07808E0B766753C3292 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig */;
+			baseConfigurationReference = 09E86ACB70C1454B76E222B5 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -831,7 +847,7 @@
 		};
 		8094CA5228EDC65900E70F76 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3799B6D3405FAB35D79C7103 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig */;
+			baseConfigurationReference = 6601033F99ABB4CE0338C61C /* Pods-NostelgiAlbum-NostelgiAlbumUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/NostelgiAlbum.xcodeproj/project.pbxproj
+++ b/NostelgiAlbum.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		8320291F295EA8E2001709E9 /* AlbumEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320291E295EA8E2001709E9 /* AlbumEditViewController.swift */; };
 		83C615C8298B978D0018BBAF /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615C7298B978D0018BBAF /* ShareViewController.swift */; };
 		83C615CA298BA3C90018BBAF /* UTI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615C9298BA3C90018BBAF /* UTI.swift */; };
+		83C615F1298EBB010018BBAF /* SharingAlbumPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615F0298EBB010018BBAF /* SharingAlbumPush.swift */; };
 		9637805CE99D7E121BEE0717 /* Pods_NostelgiAlbum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A0A83F13AEEA742D0FD55A4 /* Pods_NostelgiAlbum.framework */; };
 /* End PBXBuildFile section */
 
@@ -90,6 +91,7 @@
 		8320291E295EA8E2001709E9 /* AlbumEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumEditViewController.swift; sourceTree = "<group>"; };
 		83C615C7298B978D0018BBAF /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		83C615C9298BA3C90018BBAF /* UTI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTI.swift; sourceTree = "<group>"; };
+		83C615F0298EBB010018BBAF /* SharingAlbumPush.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingAlbumPush.swift; sourceTree = "<group>"; };
 		884CF07808E0B766753C3292 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum-NostelgiAlbumUITests/Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		8FFC13E4AFBFFF078784A65D /* Pods-NostelgiAlbum.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum.release.xcconfig"; sourceTree = "<group>"; };
 		A37BCC6121739C6133FF1DE6 /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NostelgiAlbum_NostelgiAlbumUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -213,6 +215,7 @@
 				8092C3A4298CF1AA007FFEF3 /* CollectionView+ButtonAction.swift */,
 				8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */,
 				831A0521297A9BCA009D26A0 /* HomeDetailController */,
+				83C615F0298EBB010018BBAF /* SharingAlbumPush.swift */,
 			);
 			path = HomeScreenViewController;
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83C615F1298EBB010018BBAF /* SharingAlbumPush.swift in Sources */,
 				83C615CA298BA3C90018BBAF /* UTI.swift in Sources */,
 				8020034B290FBB9200FCD54F /* AlbumScreenViewController.swift in Sources */,
 				831A04D8295EBDCA009D26A0 /* AlbumPicViewController.swift in Sources */,

--- a/NostelgiAlbum.xcodeproj/project.pbxproj
+++ b/NostelgiAlbum.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		831A04D8295EBDCA009D26A0 /* AlbumPicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831A04D7295EBDCA009D26A0 /* AlbumPicViewController.swift */; };
 		831A04DA295EC04C009D26A0 /* ImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831A04D9295EC04C009D26A0 /* ImageViewController.swift */; };
 		8320291F295EA8E2001709E9 /* AlbumEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320291E295EA8E2001709E9 /* AlbumEditViewController.swift */; };
+		83C615C8298B978D0018BBAF /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615C7298B978D0018BBAF /* ShareViewController.swift */; };
+		83C615CA298BA3C90018BBAF /* UTI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C615C9298BA3C90018BBAF /* UTI.swift */; };
 		9637805CE99D7E121BEE0717 /* Pods_NostelgiAlbum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A0A83F13AEEA742D0FD55A4 /* Pods_NostelgiAlbum.framework */; };
 /* End PBXBuildFile section */
 
@@ -80,6 +82,8 @@
 		831A04D7295EBDCA009D26A0 /* AlbumPicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumPicViewController.swift; sourceTree = "<group>"; };
 		831A04D9295EC04C009D26A0 /* ImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewController.swift; sourceTree = "<group>"; };
 		8320291E295EA8E2001709E9 /* AlbumEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumEditViewController.swift; sourceTree = "<group>"; };
+		83C615C7298B978D0018BBAF /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		83C615C9298BA3C90018BBAF /* UTI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTI.swift; sourceTree = "<group>"; };
 		884CF07808E0B766753C3292 /* Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum-NostelgiAlbumUITests/Pods-NostelgiAlbum-NostelgiAlbumUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		8FFC13E4AFBFFF078784A65D /* Pods-NostelgiAlbum.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum.release.xcconfig"; sourceTree = "<group>"; };
 		A37BCC6121739C6133FF1DE6 /* Pods_NostelgiAlbum_NostelgiAlbumUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NostelgiAlbum_NostelgiAlbumUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -153,6 +157,7 @@
 		8094CA2228EDC65500E70F76 /* NostelgiAlbum */ = {
 			isa = PBXGroup;
 			children = (
+				83C615C7298B978D0018BBAF /* ShareViewController.swift */,
 				831A051F297A9B6E009D26A0 /* Model */,
 				8094CA2928EDC65500E70F76 /* Main.storyboard */,
 				8094CA2E28EDC65900E70F76 /* LaunchScreen.storyboard */,
@@ -164,6 +169,7 @@
 				831A0525297A9BFE009D26A0 /* ImageFunc */,
 				8094CA2C28EDC65900E70F76 /* Assets.xcassets */,
 				8094CA3128EDC65900E70F76 /* Info.plist */,
+				83C615C9298BA3C90018BBAF /* UTI.swift */,
 			);
 			path = NostelgiAlbum;
 			sourceTree = "<group>";
@@ -498,12 +504,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83C615CA298BA3C90018BBAF /* UTI.swift in Sources */,
 				8020034B290FBB9200FCD54F /* AlbumScreenViewController.swift in Sources */,
 				831A04D8295EBDCA009D26A0 /* AlbumPicViewController.swift in Sources */,
 				804C7E8E295835D200C63880 /* ImageFunc.swift in Sources */,
 				807FF50129260656005D9884 /* InfoToolTableViewCell.swift in Sources */,
 				8002F65328EE905B00E9913D /* HomeScreenViewController.swift in Sources */,
 				8002F65528EE9D1800E9913D /* HomeScreenCollectionViewCell.swift in Sources */,
+				83C615C8298B978D0018BBAF /* ShareViewController.swift in Sources */,
 				8094CA2428EDC65500E70F76 /* AppDelegate.swift in Sources */,
 				831A04DA295EC04C009D26A0 /* ImageViewController.swift in Sources */,
 				80DF50AE290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift in Sources */,
@@ -690,9 +698,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8A6XY8WY2J;
+				DEVELOPMENT_TEAM = N7AA7Y5KM6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NostelgiAlbum/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = test;
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = test;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -703,7 +713,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mingu.NostelgiAlbum;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chopmozzi.NostelgiAlbum;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -719,9 +729,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8A6XY8WY2J;
+				DEVELOPMENT_TEAM = N7AA7Y5KM6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NostelgiAlbum/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = test;
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = test;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -732,7 +744,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mingu.NostelgiAlbum;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chopmozzi.NostelgiAlbum;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
@@ -4,7 +4,7 @@ import RealmSwift
 class AlbumEditViewController: UIViewController {
 
     @IBOutlet weak var editText: UITextView!
-    @IBOutlet weak var editTitle: UITextField!
+    @IBOutlet weak var editName: UITextField!
     @IBOutlet weak var editPicture: UIButton!
     var collectionViewInAlbum : UICollectionView!
     var index : Int!
@@ -15,7 +15,6 @@ class AlbumEditViewController: UIViewController {
         super.viewDidLoad()
         if picture != nil
         {
-            print("choppicture:",picture.ImageName)
             transPic(picture)
         } else {
             editPicture.setImage(UIImage(systemName: "photo"), for: .normal)
@@ -60,7 +59,7 @@ class AlbumEditViewController: UIViewController {
         let totalPath = "\(picture.AlbumTitle)_\(picture.perAlbumIndex).png"
         editPicture.setImage(loadImageFromDocumentDirectory(imageName: totalPath, albumTitle: picture.AlbumTitle)?.resize(newWidth: editPicture.frame.size.width, newHeight: editPicture.frame.size.height), for: .normal)
         editPicture.setTitle("", for: .normal)
-        editTitle.text = picture.AlbumTitle
+        editName.text = picture.ImageName
         editText.text = picture.ImageText
     }
     
@@ -68,7 +67,7 @@ class AlbumEditViewController: UIViewController {
         let realm = try! Realm()
         let updPicture = (realm.objects(album.self).filter("index = \(picture.index)"))
         try! realm.write {
-            updPicture[picture.perAlbumIndex - 1].ImageName = editTitle.text!
+            updPicture[picture.perAlbumIndex - 1].ImageName = editName.text!
             updPicture[picture.perAlbumIndex - 1].ImageText = editText.text!
         }
         let totalPath = "\(picture.AlbumTitle)_\(picture.perAlbumIndex).png"
@@ -78,7 +77,7 @@ class AlbumEditViewController: UIViewController {
         let realm = try! Realm()
         let newPicture = album()
         let data = (realm.objects(albumsInfo.self).filter("id = \(index!)"))
-        newPicture.ImageName = editTitle.text!
+        newPicture.ImageName = editName.text!
         newPicture.ImageText = editText.text!
         newPicture.index = index
         newPicture.AlbumTitle = albumCoverName
@@ -104,7 +103,7 @@ class AlbumEditViewController: UIViewController {
                 imageAlert.view.superview?.addGestureRecognizer(tap)
             }
             return
-        } else if editTitle.text == "" {
+        } else if editName.text == "" {
             let imageAlert = UIAlertController(title: "빈 제목", message: "사진 제목을 입력해주세요", preferredStyle: UIAlertController.Style.alert)
             present(imageAlert, animated: true){
                 let tap = UITapGestureRecognizer(target: self, action: #selector(self.didTappedOutside(_:)))

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
@@ -26,6 +26,10 @@ class AlbumEditViewController: UIViewController {
         self.view.addGestureRecognizer(swipeRecognizer)
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?){
+          self.view.endEditing(true)
+    }
+    
     @IBAction func addAlbumPicture(_ sender: Any) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let library = UIAlertAction(title: "사진 앨범", style: .default){(action) in self.openLibrary()}

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumPicViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumPicViewController.swift
@@ -32,8 +32,6 @@ class AlbumPicViewController: UIViewController {
         guard let picVC = self.presentingViewController else { return }
         editVC.picture = picture
         editVC.collectionViewInAlbum = collectionViewInAlbum
-        //editVC.editPicture.setImage(UIImage(named: self.picture.ImageName)?.resize(newWidth: 312), for: .normal)
-        //editVC.editPicture.setTitle("", for: .normal)
         editVC.modalPresentationStyle = .overFullScreen
         self.dismiss(animated: false) {
             picVC.present(editVC, animated: false)

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewController.swift
@@ -83,28 +83,40 @@ class AlbumScreenViewController: UIViewController {
     }
     
     @objc func shareButton() {
-        //let items = ["chopmojji"]
-        //let ac = UIActivityViewController(activityItems: items, applicationActivities: nil)
         let coverData = realm.objects(albumCover.self).filter("id = \(coverIndex)")
-        let shareText: String = "share text test!"
         var shareObject = [Any]()
-        //let filePath = Bundle.main.url(forResource: "찹모찌", withExtension: "zip")!
-        //let filePath = "/찹모찌"
-        //print("test filepath :",filePath)
         let fileURL = zipAlbumDirectory(AlbumCoverName: coverData.first!.albumName)
         do {
             let attributes = try FileManager.default.attributesOfItem(atPath: fileURL!.path)
-            let permissions = attributes[.posixPermissions] as! Int
+            let permissions =
+            attributes[.posixPermissions] as! Int
             let newPermissions = permissions | Int(0o777)
             try FileManager.default.setAttributes([.posixPermissions: newPermissions], ofItemAtPath: fileURL!.path)
         } catch {
             print("Error setting file permissions: \(error)")
         }
         print("coverData",coverData.first!.albumName)
-        shareObject.append(shareText)
         shareObject.append(fileURL!)
         let ac = UIActivityViewController(activityItems: shareObject, applicationActivities: nil)
-        ac.popoverPresentationController?.sourceView = self.view
+        ac.completionWithItemsHandler = {(activityType: UIActivity.ActivityType?, completed: Bool, returnedItems: [Any]?, error: Error?) in
+            if completed {
+                print("true")
+                do {
+                    try FileManager.default.removeItem(at: fileURL!)
+                } catch {
+                    print("Error removing file")
+                }
+            } else {
+                print("false")
+                do {
+                    try FileManager.default.removeItem(at: fileURL!)
+                } catch {
+                    print("Error removing file")
+                }
+            }
+        }
+        
+        //ac.popoverPresentationController?.sourceView = self.view
         self.present(ac, animated: true, completion: nil)
     }
     

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 import RealmSwift
-
+import Zip
 class AlbumScreenViewController: UIViewController {
     
     @IBOutlet weak var pageNumLabel: UILabel!
@@ -43,11 +43,10 @@ class AlbumScreenViewController: UIViewController {
     // Set toolBar
     private func makeToolbarItems() -> [UIBarButtonItem]{
         let searchButton = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: #selector(AlbumScreenViewController.searchButton))
-        let shareButton = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: nil)
+        let shareButton = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: #selector(AlbumScreenViewController.shareButton))
         let settingButton = UIBarButtonItem(image: UIImage(systemName: "gearshape")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: nil)
         let informationButton = UIBarButtonItem(image: UIImage(systemName: "info.square")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: #selector(AlbumScreenViewController.infoButton))
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
-        
         return [searchButton, flexibleSpace, shareButton, flexibleSpace, settingButton, flexibleSpace, informationButton]
     }
     
@@ -82,6 +81,37 @@ class AlbumScreenViewController: UIViewController {
             }
         }
     }
+    
+    @objc func shareButton() {
+        //let items = ["chopmojji"]
+        //let ac = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        let coverData = realm.objects(albumCover.self).filter("id = \(coverIndex)")
+        let shareText: String = "share text test!"
+        var shareObject = [Any]()
+        //let filePath = Bundle.main.url(forResource: "찹모찌", withExtension: "zip")!
+        //let filePath = "/찹모찌"
+        //print("test filepath :",filePath)
+        let fileURL = zipAlbumDirectory(AlbumCoverName: coverData.first!.albumName)
+        do {
+            let attributes = try FileManager.default.attributesOfItem(atPath: fileURL!.path)
+            let permissions = attributes[.posixPermissions] as! Int
+            let newPermissions = permissions | Int(0o777)
+            try FileManager.default.setAttributes([.posixPermissions: newPermissions], ofItemAtPath: fileURL!.path)
+        } catch {
+            print("Error setting file permissions: \(error)")
+        }
+        print("coverData",coverData.first!.albumName)
+        shareObject.append(shareText)
+        shareObject.append(fileURL!)
+        let ac = UIActivityViewController(activityItems: shareObject, applicationActivities: nil)
+        ac.popoverPresentationController?.sourceView = self.view
+        self.present(ac, animated: true, completion: nil)
+    }
+    
+    class customShareButton : UIBarButtonItem {
+        var test : String!
+    }
+    
     @objc func infoButton(){
         guard let infoVC = self.storyboard?.instantiateViewController(identifier: "InfoToolViewController") as? InfoToolViewController else { return }
         infoVC.index = coverIndex

--- a/NostelgiAlbum/AlbumScreenViewController/ToolBarButtonAction.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/ToolBarButtonAction.swift
@@ -1,0 +1,97 @@
+import UIKit
+
+extension AlbumScreenViewController {
+    //search button을 누를 시 동작
+    @objc func searchButton(){
+        guard let searchVC = self.storyboard?.instantiateViewController(withIdentifier: "SearchToolViewController") as? SearchToolViewController else {return}
+        searchVC.modalPresentationStyle = .overCurrentContext
+        searchVC.delegate = self
+        self.present(searchVC, animated: false)
+    }
+        
+    //share button을 누를 시 동작
+    @objc func shareButton() {
+        let coverData = realm.objects(albumCover.self).filter("id = \(coverIndex)")
+        //공유할 Object
+        var shareObject = [Any]()
+        //현재 앨범을 압축
+        let fileURL = zipAlbumDirectory(AlbumCoverName: coverData.first!.albumName)
+        //권한 부여(필요 유무 확인 필)
+        do {
+            let attributes = try FileManager.default.attributesOfItem(atPath: fileURL!.path)
+            let permissions =
+            attributes[.posixPermissions] as! Int
+            let newPermissions = permissions | Int(0o777)
+            try FileManager.default.setAttributes([.posixPermissions: newPermissions], ofItemAtPath: fileURL!.path)
+        } catch {
+            print("Error setting file permissions: \(error)")
+        }
+        //공유 Object에 추가
+        shareObject.append(fileURL!)
+        //Open share sheet with shareobject
+        let ac = UIActivityViewController(activityItems: shareObject, applicationActivities: nil)
+        //share sheet가 닫히면 .nost파일 삭제
+        ac.completionWithItemsHandler = {(activityType: UIActivity.ActivityType?, completed: Bool, returnedItems: [Any]?, error: Error?) in
+            if completed {
+                do {
+                    try FileManager.default.removeItem(at: fileURL!)
+                } catch {
+                    print("Error removing file")
+                }
+            } else {
+                do {
+                    try FileManager.default.removeItem(at: fileURL!)
+                } catch {
+                    print("Error removing file")
+                }
+            }
+        }
+        //open share sheet
+        self.present(ac, animated: true, completion: nil)
+    }
+    
+    //info button을 누를 시 동작
+    @objc func infoButton(){
+        guard let infoVC = self.storyboard?.instantiateViewController(identifier: "InfoToolViewController") as? InfoToolViewController else { return }
+        infoVC.index = coverIndex
+        infoVC.modalTransitionStyle = .crossDissolve
+        infoVC.modalPresentationStyle = .overCurrentContext
+        self.present(infoVC, animated: true, completion: nil)
+    }
+}
+
+/*
+ searchButton을 눌렀을 때 실행되는 function(using DisDelegate)
+ */
+extension AlbumScreenViewController: DisDelegate{
+    //text는 검색 시 입력한 내용
+    func delegateString(text: String) {
+        let data = realm.objects(album.self).filter("index = \(coverIndex)")
+        var num : Int = 0
+        var checkcount : Int = pageNum
+        //Album내 페이지 viewControllers목록(NavigationController를 통해 관리)
+        let viewControllers: [UIViewController] = self.navigationController!.viewControllers as [UIViewController]
+        //검색한 내용이 있을 경우
+        if let result = data.firstIndex(where: {$0.ImageName == text}){
+            guard let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "AlbumScreenViewController") as? AlbumScreenViewController else{ return }
+            if(result/2 > checkcount){
+                //한 개씩 push
+                while checkcount < result/2 {
+                    checkcount = checkcount + 1
+                    pushVC.pageNum = checkcount
+                    pushVC.coverIndex = self.coverIndex
+                    self.navigationController?.pushViewController(pushVC, animated: false)
+                }
+            } else { //pop해서 이동할 viewcontrollers까지의 count 찾기
+                while checkcount >= result/2 {
+                    checkcount = checkcount - 1
+                    num = num + 1
+                }
+                //해당 count만큼 pop
+                self.navigationController!.popToViewController(viewControllers[viewControllers.count - num], animated: false)
+            }
+        } else {
+            print("none")
+        }
+    }
+}

--- a/NostelgiAlbum/AppDelegate.swift
+++ b/NostelgiAlbum/AppDelegate.swift
@@ -3,10 +3,7 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         return true
     }
 
@@ -24,6 +21,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if url.scheme == "com.chopmozzi.NostelgiAlbum" {
+            print("mozzi")
+            return true
+        }
+        print("error!")
+        return false
+    }
 
 }
 

--- a/NostelgiAlbum/AppDelegate.swift
+++ b/NostelgiAlbum/AppDelegate.swift
@@ -3,6 +3,8 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    var window: UIWindow?
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         return true
     }
@@ -21,14 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        if url.scheme == "com.chopmozzi.NostelgiAlbum" {
-            print("mozzi")
-            return true
-        }
-        print("error!")
-        return false
-    }
+    
 
 }
 

--- a/NostelgiAlbum/Base.lproj/Main.storyboard
+++ b/NostelgiAlbum/Base.lproj/Main.storyboard
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hiT-n4-Ish">
-    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -14,11 +13,11 @@
             <objects>
                 <viewController storyboardIdentifier="HomeScreenViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="HomeScreenViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="INu-ib-KxC">
-                                <rect key="frame" x="0.0" y="110" width="393" height="568"/>
+                                <rect key="frame" x="0.0" y="51" width="600" height="409"/>
                                 <color key="backgroundColor" red="0.40000003579999999" green="0.2901961207" blue="0.231372565" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Jsa-mu-Jfp">
                                     <size key="itemSize" width="390" height="191"/>
@@ -28,7 +27,7 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeScreenCollectionViewCell" id="Xdi-Mm-CLH" customClass="HomeScreenCollectionViewCell" customModule="NostelgiAlbum" customModuleProvider="target">
-                                        <rect key="frame" x="1.6666666666666667" y="0.0" width="390" height="191"/>
+                                        <rect key="frame" x="105" y="0.0" width="390" height="191"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="n9d-vr-h7a">
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="191"/>
@@ -119,7 +118,7 @@
                                 </cells>
                             </collectionView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NostelgiAlbum" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FCk-00-G7W">
-                                <rect key="frame" x="0.0" y="678" width="393" height="140"/>
+                                <rect key="frame" x="0.0" y="460" width="600" height="140"/>
                                 <color key="backgroundColor" red="0.40000000000000002" green="0.2901960784" blue="0.23137254900000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="140" id="trj-3m-0KB"/>
@@ -129,7 +128,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lwh-i1-Wmq" userLabel="Top">
-                                <rect key="frame" x="0.0" y="103" width="393" height="7"/>
+                                <rect key="frame" x="0.0" y="44" width="600" height="7"/>
                                 <color key="backgroundColor" red="0.23497083760000001" green="0.17027528459999999" blue="0.1365594789" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="7" id="6hO-ES-XHi"/>
@@ -189,11 +188,11 @@
             <objects>
                 <viewController storyboardIdentifier="AlbumScreenViewController" title="Album" id="SB1-ha-RU1" customClass="AlbumScreenViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="VRb-P6-i6I">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="arc-jP-fUr">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <color key="backgroundColor" red="0.40000003579999999" green="0.2901961207" blue="0.231372565" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Gtc-CE-h3w">
                                     <size key="itemSize" width="389" height="315"/>
@@ -203,7 +202,7 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AlbumScreenCollectionViewCell" id="LeX-79-3Ln" customClass="AlbumScreenCollectionViewCell" customModule="NostelgiAlbum" customModuleProvider="target">
-                                        <rect key="frame" x="2" y="0.0" width="389" height="315"/>
+                                        <rect key="frame" x="105.66666666666667" y="0.0" width="389" height="315"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="xV3-Yn-Nql">
                                             <rect key="frame" x="0.0" y="0.0" width="389" height="315"/>
@@ -280,14 +279,14 @@
             <objects>
                 <viewController storyboardIdentifier="AlbumEditViewController" id="qGg-ET-l2z" customClass="AlbumEditViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="snJ-Kh-xcU">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x16-SJ-OeI">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pDz-rf-7Ho">
-                                        <rect key="frame" x="307" y="20" width="66" height="35"/>
+                                        <rect key="frame" x="514" y="20" width="66" height="35"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="SAVE"/>
                                         <connections>
@@ -295,7 +294,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pul-iH-fuh">
-                                        <rect key="frame" x="10" y="75" width="373" height="450"/>
+                                        <rect key="frame" x="10" y="75" width="580" height="450"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="450" id="zKh-Oh-Eby"/>
                                         </constraints>
@@ -306,12 +305,12 @@
                                         </connections>
                                     </button>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="사진제목" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="29r-LZ-69x">
-                                        <rect key="frame" x="20" y="525" width="353" height="34"/>
+                                        <rect key="frame" x="20" y="525" width="560" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qd4-6a-Gz8">
-                                        <rect key="frame" x="20" y="579" width="353" height="160"/>
+                                        <rect key="frame" x="20" y="579" width="560" height="1"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <color key="textColor" systemColor="labelColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -346,9 +345,9 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="editName" destination="29r-LZ-69x" id="I9p-eu-dMN"/>
                         <outlet property="editPicture" destination="pul-iH-fuh" id="xvV-8b-Emc"/>
                         <outlet property="editText" destination="qd4-6a-Gz8" id="LcF-Vj-Iee"/>
-                        <outlet property="editTitle" destination="29r-LZ-69x" id="I9p-eu-dMN"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UPA-Ui-UH1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -360,20 +359,20 @@
             <objects>
                 <viewController storyboardIdentifier="AlbumPicViewController" id="8u0-KJ-518" customClass="AlbumPicViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="wrg-tO-7M3">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="blZ-Tc-pwX">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DJL-vM-fOY">
-                                        <rect key="frame" x="30" y="518.66666666666663" width="333" height="20.333333333333371"/>
+                                        <rect key="frame" x="30" y="524.33333333333337" width="540" height="20.333333333333371"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U9I-5N-ooA">
-                                        <rect key="frame" x="30" y="539" width="333" height="200"/>
+                                        <rect key="frame" x="30" y="544.66666666666663" width="540" height="200"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="200" id="gbf-Vc-MUk"/>
                                         </constraints>
@@ -382,7 +381,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iX7-Vq-biM">
-                                        <rect key="frame" x="298" y="20" width="75" height="28.666666666666671"/>
+                                        <rect key="frame" x="298" y="20.000000000000004" width="282" height="34.333333333333343"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                         <connections>
@@ -390,7 +389,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="izs-d9-9Yf">
-                                        <rect key="frame" x="10" y="68.666666666666686" width="373" height="450.00000000000006"/>
+                                        <rect key="frame" x="10" y="74.333333333333314" width="580" height="449.99999999999994"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="450" id="di3-Ug-teD"/>
                                         </constraints>
@@ -444,14 +443,14 @@
             <objects>
                 <viewController storyboardIdentifier="ImageViewController" id="NcE-4x-cJB" customClass="ImageViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="s0s-tL-iVr">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="se2-oU-f4c">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PEh-wv-ahH">
-                                <rect key="frame" x="298" y="79" width="75" height="35"/>
+                                <rect key="frame" x="505" y="20" width="75" height="35"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                 <connections>
@@ -484,7 +483,7 @@
             <objects>
                 <viewController storyboardIdentifier="ShareViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="0TT-Up-5Uc" customClass="ShareViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="SF3-as-Dv6">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HCt-Vc-6G7">
@@ -520,11 +519,11 @@
             <objects>
                 <viewController storyboardIdentifier="SearchToolViewController" id="kMX-HM-r06" customClass="SearchToolViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="iEM-pC-rNI">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bBD-hI-lpc">
-                                <rect key="frame" x="30" y="340" width="333" height="164"/>
+                                <rect key="frame" x="30" y="281" width="540" height="5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="검색" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ORK-0F-ozm">
                                         <rect key="frame" x="139" y="31" width="30" height="21"/>
@@ -561,7 +560,7 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1ch-VZ-qWX">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
@@ -591,23 +590,23 @@
             <objects>
                 <viewController storyboardIdentifier="InfoToolViewController" id="Lfu-wu-8ao" customClass="InfoToolViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="KAn-f1-EQX">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X7s-TT-gLd">
-                                <rect key="frame" x="117" y="79" width="162" height="36"/>
+                                <rect key="frame" x="324" y="20" width="162" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="jVO-JZ-nFN">
-                                <rect key="frame" x="20" y="145" width="353" height="673"/>
+                                <rect key="frame" x="20" y="86" width="560" height="514"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="InfoToolTableViewCell" id="R6e-ZQ-THE" customClass="InfoToolTableViewCell" customModule="NostelgiAlbum" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="353" height="43.666667938232422"/>
+                                        <rect key="frame" x="0.0" y="50" width="560" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="R6e-ZQ-THE" id="G7h-6S-5Es">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="560" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YCQ-gu-VyH">
@@ -634,7 +633,7 @@
                                 </prototypes>
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33K-Bl-YlN">
-                                <rect key="frame" x="20" y="79" width="62" height="36"/>
+                                <rect key="frame" x="20" y="20" width="269" height="36"/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
                                 <color key="tintColor" systemColor="labelColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -675,15 +674,15 @@
             <objects>
                 <viewController storyboardIdentifier="HomeEditViewController" id="uG1-g0-tif" customClass="HomeEditViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="W9P-Ih-jmQ">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view alpha="0.75" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kBP-fR-9mu">
-                                <rect key="frame" x="0.0" y="59" width="393" height="710"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="551"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sRN-Fp-mgI" userLabel="PopUpView">
-                                <rect key="frame" x="30" y="221.66666666666663" width="333" height="385"/>
+                                <rect key="frame" x="133.66666666666663" y="83" width="333" height="385"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="앨범 명" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W6f-sn-2kD">
                                         <rect key="frame" x="36" y="102" width="39" height="19.666666666666671"/>

--- a/NostelgiAlbum/Base.lproj/Main.storyboard
+++ b/NostelgiAlbum/Base.lproj/Main.storyboard
@@ -334,9 +334,6 @@
                                     <constraint firstItem="qd4-6a-Gz8" firstAttribute="top" secondItem="29r-LZ-69x" secondAttribute="bottom" constant="20" id="v58-rc-sKD"/>
                                     <constraint firstAttribute="trailing" secondItem="29r-LZ-69x" secondAttribute="trailing" constant="20" id="x6H-qL-LYX"/>
                                 </constraints>
-                                <connections>
-                                    <outletCollection property="gestureRecognizers" destination="3RP-Kc-9ts" appends="YES" id="x2D-Ig-U8m"/>
-                                </connections>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="3Cf-Ao-r4Y"/>
@@ -355,7 +352,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UPA-Ui-UH1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <swipeGestureRecognizer direction="right" id="3RP-Kc-9ts"/>
             </objects>
             <point key="canvasLocation" x="2100" y="930.98591549295782"/>
         </scene>
@@ -482,6 +478,32 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="t13-Cp-Lf7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3701.5267175572517" y="930.98591549295782"/>
+        </scene>
+        <!--Share View Controller-->
+        <scene sceneID="7HD-nO-WPm">
+            <objects>
+                <viewController id="0TT-Up-5Uc" customClass="ShareViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="SF3-as-Dv6">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HCt-Vc-6G7">
+                                <rect key="frame" x="159" y="453" width="75" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <action selector="openInButtonTapped:" destination="0TT-Up-5Uc" eventType="touchUpInside" id="bkx-Cb-LQT"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="caf-Pt-DJ6"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4aB-xR-WZd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4458.7786259541981" y="937.32394366197184"/>
         </scene>
         <!--Search Tool View Controller-->
         <scene sceneID="qNM-Qk-sLk">

--- a/NostelgiAlbum/Base.lproj/Main.storyboard
+++ b/NostelgiAlbum/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--Home-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="HomeScreenViewController" id="BYZ-38-t0r" customClass="HomeScreenViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="HomeScreenViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="HomeScreenViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -167,7 +167,7 @@
         <!--Item-->
         <scene sceneID="ulJ-yu-Wrh">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="hiT-n4-Ish" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="NavigationController" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hiT-n4-Ish" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Item" id="ewR-Ce-7Tb"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="kji-X1-zRU">
@@ -482,13 +482,13 @@
         <!--Share View Controller-->
         <scene sceneID="7HD-nO-WPm">
             <objects>
-                <viewController id="0TT-Up-5Uc" customClass="ShareViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ShareViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="0TT-Up-5Uc" customClass="ShareViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="SF3-as-Dv6">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HCt-Vc-6G7">
-                                <rect key="frame" x="159" y="453" width="75" height="35"/>
+                                <rect key="frame" x="159" y="565" width="75" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
@@ -496,10 +496,20 @@
                                     <action selector="openInButtonTapped:" destination="0TT-Up-5Uc" eventType="touchUpInside" id="bkx-Cb-LQT"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L59-gQ-sFJ">
+                                <rect key="frame" x="16" y="297" width="361" height="93"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="caf-Pt-DJ6"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <connections>
+                        <outlet property="albumInfoLabel" destination="L59-gQ-sFJ" id="zKU-Yt-owg"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4aB-xR-WZd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/NostelgiAlbum/HomeScreenViewController/CollectionView+ButtonAction.swift
+++ b/NostelgiAlbum/HomeScreenViewController/CollectionView+ButtonAction.swift
@@ -132,5 +132,4 @@ extension HomeScreenViewController {
         dismiss(animated: true, completion: nil)
         
     }
-    
 }

--- a/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController+CollectionView.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController+CollectionView.swift
@@ -69,6 +69,7 @@ extension HomeScreenViewController: UICollectionViewDataSource{
                 self.present(editVC, animated: false)
             }
             else {
+                print("chop")
                 let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "AlbumScreenViewController") as! AlbumScreenViewController
                 pushVC.pageNum = 0
                 pushVC.coverIndex = indexPath.row * 2 + 1

--- a/NostelgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
+++ b/NostelgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
@@ -1,14 +1,13 @@
 import UIKit
 
 extension HomeScreenViewController {
-        
+    //HomeScreenViewController에서 ShareView를 push합니다.
     func pushShareView(path: URL) {
-        print("chomozzi")
         let shareVC = self.storyboard?.instantiateViewController(withIdentifier: "ShareViewController") as! ShareViewController
+        //.nost파일의 URL
         shareVC.filePath = path
+        //HomeScreenViewController의 collectionView Object
         shareVC.collectionViewInHome = collectionView
-        shareVC.modalPresentationStyle = .fullScreen
         self.navigationController?.pushViewController(shareVC, animated: true)
-        //self.present(shareVC, animated: true)
     }
 }

--- a/NostelgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
+++ b/NostelgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+extension HomeScreenViewController {
+        
+    func pushShareView(path: URL) {
+        print("chomozzi")
+        let shareVC = self.storyboard?.instantiateViewController(withIdentifier: "ShareViewController") as! ShareViewController
+        shareVC.filePath = path
+        shareVC.collectionViewInHome = collectionView
+        shareVC.modalPresentationStyle = .fullScreen
+        self.navigationController?.pushViewController(shareVC, animated: true)
+        //self.present(shareVC, animated: true)
+    }
+}

--- a/NostelgiAlbum/ImageFunc/ImageFunc.swift
+++ b/NostelgiAlbum/ImageFunc/ImageFunc.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Zip
 
 func saveImageToDocumentDirectory(imageName: String, image: UIImage, AlbumCoverName: String) {
     // 1. 이미지를 저장할 경로를 설정해줘야함 - 도큐먼트 폴더,File 관련된건 Filemanager가 관리함(싱글톤 패턴)
@@ -68,6 +69,55 @@ func deleteImageFromDocumentDirectory(imageName: String) {
         } catch {
             print("이미지를 삭제하지 못했습니다.")
         }
+    }
+}
+
+func zipAlbumDirectory(AlbumCoverName: String) -> URL? {
+    guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return nil}
+    let dirURL = documentDirectory.appendingPathComponent(AlbumCoverName)
+    print("dirURL",dirURL.path)
+    let nostURL = documentDirectory.appendingPathComponent("\(AlbumCoverName).nost")
+    let fileManager = FileManager.default
+    do {
+        let zipfilePath = try Zip.quickZipFiles([dirURL], fileName: AlbumCoverName)
+        do {
+            if FileManager.default.fileExists(atPath: nostURL.path) {
+                do {
+                    try FileManager.default.removeItem(at: nostURL)
+                    print("nost파일 삭제 완료")
+                } catch {
+                    print("nost파일을 삭제하지 못했습니다.")
+                }
+            }
+            //try fileManager.moveItem(atPath: zipfilePath.path, toPath: nostURL.path)
+            if let data = try? Data(contentsOf: zipfilePath) {
+                let newURL = URL(filePath: nostURL.path)
+                try? data.write(to: newURL)
+            } else {
+                print("Error rewrite file")
+            }
+        }
+    } catch {
+        print("Something went wrong")
+    }
+    return nostURL
+    
+}
+
+func unzipAlbumDirectory(AlbumCoverName: String) {
+    
+}
+
+func exportNost() {
+    guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+    let data: Data = "chopmojji".data(using: .utf8)!
+    let fileName = "chopmozzi"
+    let fileURL = documentDirectory.appendingPathComponent(fileName)
+    
+    do {
+        try data.write(to: fileURL)
+    } catch {
+        print("Error")
     }
 }
 

--- a/NostelgiAlbum/Info.plist
+++ b/NostelgiAlbum/Info.plist
@@ -2,10 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSCameraUsageDescription</key>
-	<string>test</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>test</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>NostelgiAlbum</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.AppInApple.nost</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -25,5 +36,46 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Album file</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.AppInApple.nost</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>nost</string>
+				</array>
+				<key>public.mime-type</key>
+				<array/>
+			</dict>
+		</dict>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.AppInApple.nost</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>nost</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/NostelgiAlbum/SceneDelegate.swift
+++ b/NostelgiAlbum/SceneDelegate.swift
@@ -6,12 +6,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url, url.scheme == "file" && url.pathExtension == "nost", let data = try? Data(contentsOf: url) {
+            (window?.rootViewController as? ShareViewController)?.filePath = url.path
+            print("urlpath",url.path)
+        }
+    }
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.

--- a/NostelgiAlbum/SceneDelegate.swift
+++ b/NostelgiAlbum/SceneDelegate.swift
@@ -8,13 +8,38 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         
         guard let _ = (scene as? UIWindowScene) else { return }
+//        let window = UIWindow(frame: UIScreen.main.bounds)
+//        let viewController = HomeScreenViewController()
+//        window.rootViewController = viewController
+//        //window.makeKeyAndVisible()
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        if let url = URLContexts.first?.url, url.scheme == "file" && url.pathExtension == "nost", let data = try? Data(contentsOf: url) {
-            (window?.rootViewController as? ShareViewController)?.filePath = url.path
-            print("urlpath",url.path)
+        //window?.rootViewController = HomeScreenViewController()
+//        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+//        let vc : UIViewController = storyboard.instantiateViewController(withIdentifier: "HomeScreenViewController") as UIViewController
+//        window?.rootViewController = vc
+//        let url = URLContexts.first?.url
+//        if(url?.scheme == "file" && url?.pathExtension == "nost")
+//        {
+//            print("urlpath",url!.path)
+//            guard let homeScreenViewController = window?.rootViewController as? HomeScreenViewController else { return }
+//            homeScreenViewController.pushShareView(path: url!)
+//        }
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let vc = storyboard.instantiateViewController(withIdentifier: "HomeScreenViewController")
+        let navigationController = UINavigationController(rootViewController: vc)
+        window?.rootViewController = vc
+        window?.rootViewController = navigationController
+        let url = URLContexts.first?.url
+        if(url?.scheme == "file" && url?.pathExtension == "nost")
+        {
+            print("urlpath",url!.path)
+            guard let homeScreenViewController = navigationController.viewControllers.first as? HomeScreenViewController else { return }
+            homeScreenViewController.pushShareView(path: url!)
         }
+
+
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/NostelgiAlbum/SceneDelegate.swift
+++ b/NostelgiAlbum/SceneDelegate.swift
@@ -8,34 +8,27 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         
         guard let _ = (scene as? UIWindowScene) else { return }
-//        let window = UIWindow(frame: UIScreen.main.bounds)
-//        let viewController = HomeScreenViewController()
-//        window.rootViewController = viewController
-//        //window.makeKeyAndVisible()
     }
-
+    /*
+     .nost파일을 통해 앱을 열 때 호출되는 함수
+     */
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        //window?.rootViewController = HomeScreenViewController()
-//        let storyboard = UIStoryboard(name: "Main", bundle: nil)
-//        let vc : UIViewController = storyboard.instantiateViewController(withIdentifier: "HomeScreenViewController") as UIViewController
-//        window?.rootViewController = vc
-//        let url = URLContexts.first?.url
-//        if(url?.scheme == "file" && url?.pathExtension == "nost")
-//        {
-//            print("urlpath",url!.path)
-//            guard let homeScreenViewController = window?.rootViewController as? HomeScreenViewController else { return }
-//            homeScreenViewController.pushShareView(path: url!)
-//        }
+        //Main.storyboard set
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        //Main.storyboard의 HomeScreenViewController객체를 가져옴
         let vc = storyboard.instantiateViewController(withIdentifier: "HomeScreenViewController")
+        //UINavigationController의 rootViewController를 HomeScreenViewController로 지정
         let navigationController = UINavigationController(rootViewController: vc)
+        //rootViewControlelr에 객체 값 할당
         window?.rootViewController = vc
         window?.rootViewController = navigationController
+        //NostelgiAlbum을 여는 경로가 .nost file일 때
         let url = URLContexts.first?.url
         if(url?.scheme == "file" && url?.pathExtension == "nost")
         {
-            print("urlpath",url!.path)
+            //navigationController.viewControllers.first == HomeScreenViewController
             guard let homeScreenViewController = navigationController.viewControllers.first as? HomeScreenViewController else { return }
+            //HomeScreenViewController의 pushShareView 동작(파일 URL을 같이 넣어줌)
             homeScreenViewController.pushShareView(path: url!)
         }
 

--- a/NostelgiAlbum/ShareViewController.swift
+++ b/NostelgiAlbum/ShareViewController.swift
@@ -1,25 +1,117 @@
-//
-//  ShareViewController.swift
-//  NostelgiAlbum
-//
-//  Created by 황지웅 on 2023/02/02.
-//
-
 import UIKit
 import UniformTypeIdentifiers
+import Zip
+import RealmSwift
 
 class ShareViewController: UIViewController, UIDocumentPickerDelegate {
 
+    
+    @IBOutlet weak var albumInfoLabel: UILabel!
+    var filePath: URL?
+    var collectionViewInHome : UICollectionView!
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        loadingAlbumInfo()
     }
-    var filePath: String?
-    
     @IBAction func openInButtonTapped(_ sender: Any) {
-        
+        guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+        let AlbumCoverName = filePath?.deletingPathExtension().lastPathComponent
+        let zipURL = documentDirectory.appendingPathComponent("\(AlbumCoverName!).zip")
+        print("zipURL",zipURL.path)
+        if let data = try? Data(contentsOf: filePath!) {
+            let newURL = URL(filePath: zipURL.path)
+            try? data.write(to: zipURL)
+            print("newURL", newURL.path)
+            do {
+                let _: () = try Zip.unzipFile(zipURL, destination: zipURL.deletingLastPathComponent(), overwrite: true, password: nil)
+                try FileManager.default.removeItem(at: newURL)
+            } catch {
+                print("Something went wrong")
+            }
+        } else {
+            print("Error rewrite zip")
+        }
+        addShareAlbum(albumURL: filePath!)
+        collectionViewInHome.reloadData()
+        //self.dismiss(animated: true)
+        self.navigationController?.popViewController(animated: true)
     }
     
- 
+    func loadingAlbumInfo() {
+        let AlbumCoverName = filePath?.deletingPathExtension().lastPathComponent
+        albumInfoLabel.text = "'\(AlbumCoverName!)'을 추가하시겠습니까?"
+    }
+}
+
+func addShareAlbum(albumURL: URL) {
+    let realm = try! Realm()
+    
+    guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+    
+    let albumCoverName = albumURL.deletingPathExtension().lastPathComponent
+    
+    let nameInfoURL = documentDirectory.appendingPathComponent(albumCoverName).appendingPathComponent("\(albumCoverName)imageNameInfo.txt")
+    
+    let textInfoURL = documentDirectory.appendingPathComponent(albumCoverName).appendingPathComponent("\(albumCoverName)imageTextInfo.txt")
+    
+    let albumInfoURL = documentDirectory.appendingPathComponent(albumCoverName).appendingPathComponent("\(albumCoverName)Info.txt")
+    
+    var arrImageName = [String]()
+    var arrImageText = [String]()
+    var arrAlbumInfo = [String]()
+    
+    do {
+        let imageNameContents = try String(contentsOfFile: nameInfoURL.path, encoding: .utf8)
+        let textInfoContents = try String(contentsOfFile: textInfoURL.path, encoding: .utf8)
+        let albumInfoContents = try String(contentsOfFile: albumInfoURL.path, encoding: .utf8)
+        let names = imageNameContents.split(separator: "\n")
+        let texts = textInfoContents.split(separator: "\n")
+        let infos = albumInfoContents.split(separator: "\n")
+        for name in names {
+            arrImageName.append("\(name)")
+        }
+        for text in texts {
+            arrImageText.append("\(text)")
+        }
+        for info in infos {
+            arrAlbumInfo.append("\(info)")
+        }
+    } catch {
+        print("File read error")
+    }
+    let shareAlbumCover = albumCover()
+    shareAlbumCover.incrementIndex()
+    shareAlbumCover.albumName = albumCoverName
+    shareAlbumCover.coverImageName = "Red"
+    
+    let shareAlbumInfo = albumsInfo()
+    shareAlbumInfo.numberOfPictures = Int(arrAlbumInfo[0])!
+    shareAlbumInfo.dateOfCreation = arrAlbumInfo[1]
+    shareAlbumInfo.incrementIndex()
+    
+    
+    for i in 1...arrImageName.count {
+        let shareAlbumImage = album()
+        shareAlbumImage.ImageName = arrImageName[i - 1]
+        shareAlbumImage.ImageText = arrImageText[i - 1]
+        shareAlbumImage.perAlbumIndex = i
+        shareAlbumImage.AlbumTitle = albumCoverName
+        shareAlbumImage.index = shareAlbumCover.id
+        try! realm.write{
+            realm.add(shareAlbumImage)
+        }
+    }
+    
+    try! realm.write{
+        realm.add(shareAlbumCover)
+        realm.add(shareAlbumInfo)
+    }
+    do {
+        try FileManager.default.removeItem(at: nameInfoURL)
+        try FileManager.default.removeItem(at: textInfoURL)
+        try FileManager.default.removeItem(at: albumInfoURL)
+    } catch {
+        print("Error removing txt")
+    }
 }

--- a/NostelgiAlbum/ShareViewController.swift
+++ b/NostelgiAlbum/ShareViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ShareViewController.swift
+//  NostelgiAlbum
+//
+//  Created by 황지웅 on 2023/02/02.
+//
+
+import UIKit
+import UniformTypeIdentifiers
+
+class ShareViewController: UIViewController, UIDocumentPickerDelegate {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    var filePath: String?
+    
+    @IBAction func openInButtonTapped(_ sender: Any) {
+        
+    }
+    
+ 
+}

--- a/NostelgiAlbum/ShareViewController.swift
+++ b/NostelgiAlbum/ShareViewController.swift
@@ -4,7 +4,6 @@ import Zip
 import RealmSwift
 
 class ShareViewController: UIViewController, UIDocumentPickerDelegate {
-
     
     @IBOutlet weak var albumInfoLabel: UILabel!
     var filePath: URL?
@@ -14,104 +13,20 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
         super.viewDidLoad()
         loadingAlbumInfo()
     }
+    
     @IBAction func openInButtonTapped(_ sender: Any) {
-        guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+        //.nost file URL에서 .nost앞 앨범 이름만 따옴
         let AlbumCoverName = filePath?.deletingPathExtension().lastPathComponent
-        let zipURL = documentDirectory.appendingPathComponent("\(AlbumCoverName!).zip")
-        print("zipURL",zipURL.path)
-        if let data = try? Data(contentsOf: filePath!) {
-            let newURL = URL(filePath: zipURL.path)
-            try? data.write(to: zipURL)
-            print("newURL", newURL.path)
-            do {
-                let _: () = try Zip.unzipFile(zipURL, destination: zipURL.deletingLastPathComponent(), overwrite: true, password: nil)
-                try FileManager.default.removeItem(at: newURL)
-            } catch {
-                print("Something went wrong")
-            }
-        } else {
-            print("Error rewrite zip")
-        }
+        unzipAlbumDirectory(AlbumCoverName: AlbumCoverName!, shareFilePath: filePath!)
+        //realm에 공유받은 album정보 write
         addShareAlbum(albumURL: filePath!)
+        //album reload
         collectionViewInHome.reloadData()
-        //self.dismiss(animated: true)
         self.navigationController?.popViewController(animated: true)
     }
     
     func loadingAlbumInfo() {
         let AlbumCoverName = filePath?.deletingPathExtension().lastPathComponent
         albumInfoLabel.text = "'\(AlbumCoverName!)'을 추가하시겠습니까?"
-    }
-}
-
-func addShareAlbum(albumURL: URL) {
-    let realm = try! Realm()
-    
-    guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
-    
-    let albumCoverName = albumURL.deletingPathExtension().lastPathComponent
-    
-    let nameInfoURL = documentDirectory.appendingPathComponent(albumCoverName).appendingPathComponent("\(albumCoverName)imageNameInfo.txt")
-    
-    let textInfoURL = documentDirectory.appendingPathComponent(albumCoverName).appendingPathComponent("\(albumCoverName)imageTextInfo.txt")
-    
-    let albumInfoURL = documentDirectory.appendingPathComponent(albumCoverName).appendingPathComponent("\(albumCoverName)Info.txt")
-    
-    var arrImageName = [String]()
-    var arrImageText = [String]()
-    var arrAlbumInfo = [String]()
-    
-    do {
-        let imageNameContents = try String(contentsOfFile: nameInfoURL.path, encoding: .utf8)
-        let textInfoContents = try String(contentsOfFile: textInfoURL.path, encoding: .utf8)
-        let albumInfoContents = try String(contentsOfFile: albumInfoURL.path, encoding: .utf8)
-        let names = imageNameContents.split(separator: "\n")
-        let texts = textInfoContents.split(separator: "\n")
-        let infos = albumInfoContents.split(separator: "\n")
-        for name in names {
-            arrImageName.append("\(name)")
-        }
-        for text in texts {
-            arrImageText.append("\(text)")
-        }
-        for info in infos {
-            arrAlbumInfo.append("\(info)")
-        }
-    } catch {
-        print("File read error")
-    }
-    let shareAlbumCover = albumCover()
-    shareAlbumCover.incrementIndex()
-    shareAlbumCover.albumName = albumCoverName
-    shareAlbumCover.coverImageName = "Red"
-    
-    let shareAlbumInfo = albumsInfo()
-    shareAlbumInfo.numberOfPictures = Int(arrAlbumInfo[0])!
-    shareAlbumInfo.dateOfCreation = arrAlbumInfo[1]
-    shareAlbumInfo.incrementIndex()
-    
-    
-    for i in 1...arrImageName.count {
-        let shareAlbumImage = album()
-        shareAlbumImage.ImageName = arrImageName[i - 1]
-        shareAlbumImage.ImageText = arrImageText[i - 1]
-        shareAlbumImage.perAlbumIndex = i
-        shareAlbumImage.AlbumTitle = albumCoverName
-        shareAlbumImage.index = shareAlbumCover.id
-        try! realm.write{
-            realm.add(shareAlbumImage)
-        }
-    }
-    
-    try! realm.write{
-        realm.add(shareAlbumCover)
-        realm.add(shareAlbumInfo)
-    }
-    do {
-        try FileManager.default.removeItem(at: nameInfoURL)
-        try FileManager.default.removeItem(at: textInfoURL)
-        try FileManager.default.removeItem(at: albumInfoURL)
-    } catch {
-        print("Error removing txt")
     }
 }

--- a/NostelgiAlbum/UTI.swift
+++ b/NostelgiAlbum/UTI.swift
@@ -1,0 +1,8 @@
+//
+//  UTI.swift
+//  NostelgiAlbum
+//
+//  Created by 황지웅 on 2023/02/02.
+//
+
+import Foundation

--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ target 'NostelgiAlbum' do
 
   # Pods for NostelgiAlbum
 	pod 'RealmSwift'
+	pod 'Zip', '~> 2.1'
   target 'NostelgiAlbumTests' do
     inherit! :search_paths
     # Pods for testing

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,19 +4,23 @@ PODS:
   - Realm/Headers (10.32.3)
   - RealmSwift (10.32.3):
     - Realm (= 10.32.3)
+  - Zip (2.1.2)
 
 DEPENDENCIES:
   - RealmSwift
+  - Zip (~> 2.1)
 
 SPEC REPOS:
   trunk:
     - Realm
     - RealmSwift
+    - Zip
 
 SPEC CHECKSUMS:
   Realm: fdf6732924dc5e69e30e0db2c11e869f92b53f3d
   RealmSwift: 7c181da8fa1c2fe613656a77c198d6a3dc3879a1
+  Zip: b3fef584b147b6e582b2256a9815c897d60ddc67
 
-PODFILE CHECKSUM: bc7f4b9642e6a66ea8809973ab4e78a7d5aa4c79
+PODFILE CHECKSUM: f6bd1b38a029700e04de1e05a5531d70808dc70a
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
## 작성 내용
- UIActivityViewController를 활용한 Album Sharing기능 구현
- share button을 클릭 시 share sheet가 열리면서 share button을 누른 위치의 Album의 공유를 할 수 있게 함
- Album은 albumdirectory가  zip -> nost의 확장자를 거쳐 공유가 되며 receiver측에서는 nost -> zip의 순서를 거쳐 unzip을 하여 album이 receiver의 album 목록에 들어갈 수 있도록 함.
- nost파일을 열 때 share sheet목록에서 NostelgiAlbum을 선택하면 app이 열리면서 공유 받을 수 있게 됨 -> `SceneDelegate`에서 `url.scheme`를 활용함
- nost라는 custom extension을 활용함에 따라 `Info.plist`수정 및 `xcodeproj`수정
- pod file에 `Zip`library추가

## 특이사항
- Mac에서 xcode simulator를 이용해 테스트 할 시 save to file을 통해 나의 iPhone폴더에 저장한 후 이용 가능
- iPhone device에 연결하여 테스트 시 카카오톡으로 파일 전송 후 파일을 다운로드 받을 시 공유 기능 테스트 가능
- 현재 자기 device로 밖에 테스트를 못하기 때문에 공유시 사용했던 album후 공유 기능 테스트를 하기 바람(directory의 이름이 똑같을 시의 예외 처리를 하지 않음)
- `SceneDelegate`에서 `rootViewController`를 활용함에 따라 viewController의 초기화에서 문제 발생(Storyboard활용에 따른)
- 주석 필요
- 코드 리팩토링 필요(hierarchy에서 용도가 맞지 않거나 불필요한 라이브러리를 import하게 되는 부분이 있음)
- 공유를 통해 받은 Album을 modifying Album기능으로 동작시킬 필요가 있음(현재 Album이름은 고정 coverImageColor는 red로 통일)
