### PR TITLE
[2023/03/02] - TextField 입력 View & 커스텀 앨범 커버 & Tool bar 고정 & HomeEditView 개선 / jeonmmingu

### DIFF
--- a/NostelgiAlbum.xcodeproj/project.pbxproj
+++ b/NostelgiAlbum.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		80A6D645299A0BE600B2D657 /* ShareFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A6D644299A0BE600B2D657 /* ShareFunc.swift */; };
 		80C56D18298CE5360063688F /* HomeScreenViewController+CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C56D17298CE5360063688F /* HomeScreenViewController+CollectionView.swift */; };
 		80DF50AE290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DF50AD290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift */; };
+		80FE482729B0832000FD0D6A /* HomeEditViewController+AlbumNameTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FE482629B0832000FD0D6A /* HomeEditViewController+AlbumNameTextField.swift */; };
 		8312C9D32921465600556BAE /* InfoToolViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8312C9D22921465600556BAE /* InfoToolViewController.swift */; };
 		8312C9D52921482A00556BAE /* SearchToolViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8312C9D42921482A00556BAE /* SearchToolViewController.swift */; };
 		831A04D8295EBDCA009D26A0 /* AlbumPicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831A04D7295EBDCA009D26A0 /* AlbumPicViewController.swift */; };
@@ -91,6 +92,7 @@
 		80A6D644299A0BE600B2D657 /* ShareFunc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFunc.swift; sourceTree = "<group>"; };
 		80C56D17298CE5360063688F /* HomeScreenViewController+CollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeScreenViewController+CollectionView.swift"; sourceTree = "<group>"; };
 		80DF50AD290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumScreenCollectionViewCell.swift; sourceTree = "<group>"; };
+		80FE482629B0832000FD0D6A /* HomeEditViewController+AlbumNameTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeEditViewController+AlbumNameTextField.swift"; sourceTree = "<group>"; };
 		8312C9D22921465600556BAE /* InfoToolViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoToolViewController.swift; sourceTree = "<group>"; };
 		8312C9D42921482A00556BAE /* SearchToolViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchToolViewController.swift; sourceTree = "<group>"; };
 		831A04D7295EBDCA009D26A0 /* AlbumPicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumPicViewController.swift; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 			children = (
 				806A653D293873C80054FAEF /* HomeEditViewController.swift */,
 				8092C3A2298CE6F0007FFEF3 /* HomeEditViewController+ButtonAction.swift */,
+				80FE482629B0832000FD0D6A /* HomeEditViewController+AlbumNameTextField.swift */,
 			);
 			path = HomeDetailController;
 			sourceTree = "<group>";
@@ -536,6 +539,7 @@
 				83C615CA298BA3C90018BBAF /* UTI.swift in Sources */,
 				831E7444299A724900D48D5C /* AlbumScreenViewGesture.swift in Sources */,
 				8020034B290FBB9200FCD54F /* AlbumScreenViewController.swift in Sources */,
+				80FE482729B0832000FD0D6A /* HomeEditViewController+AlbumNameTextField.swift in Sources */,
 				831A04D8295EBDCA009D26A0 /* AlbumPicViewController.swift in Sources */,
 				80C56D18298CE5360063688F /* HomeScreenViewController+CollectionView.swift in Sources */,
 				804C7E8E295835D200C63880 /* ImageFunc.swift in Sources */,

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
@@ -155,7 +155,8 @@ class AlbumEditViewController: UIViewController {
 
 extension AlbumEditViewController : UINavigationControllerDelegate, UIImagePickerControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage{ editPicture.imageView?.image = image
+        if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage{
+            editPicture.imageView?.image = image
             editPicture.setTitle("", for: .normal)
             editPicture.setImage(image.resize(newWidth: editPicture.frame.size.width, newHeight: editPicture.frame.size.height), for: .normal)
             dismiss(animated: true, completion: nil)

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewController.swift
@@ -34,11 +34,6 @@ class AlbumScreenViewController: UIViewController {
         navigationController?.isToolbarHidden = false
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.isToolbarHidden = true
-    }
-    
     // Set toolBar
     private func makeToolbarItems() -> [UIBarButtonItem]{
         let searchButton = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass")?.withRenderingMode(.alwaysTemplate), style: .plain, target: self, action: #selector(AlbumScreenViewController.searchButton))

--- a/NostelgiAlbum/Base.lproj/Main.storyboard
+++ b/NostelgiAlbum/Base.lproj/Main.storyboard
@@ -793,11 +793,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view alpha="0.75" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kBP-fR-9mu">
-                                <rect key="frame" x="0.0" y="59" width="393" height="710"/>
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sRN-Fp-mgI" userLabel="PopUpView">
-                                <rect key="frame" x="30" y="224" width="333" height="380"/>
+                                <rect key="frame" x="30" y="236" width="333" height="380"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="앨범 명" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W6f-sn-2kD">
                                         <rect key="frame" x="38" y="80" width="45" height="23"/>
@@ -818,7 +818,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JHW-5g-6Ba">
-                                        <rect key="frame" x="93" y="74" width="159" height="34"/>
+                                        <rect key="frame" x="93" y="74" width="149" height="34"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -914,11 +914,11 @@
                         <viewLayoutGuide key="safeArea" id="5O0-EV-K1R"/>
                         <constraints>
                             <constraint firstItem="kBP-fR-9mu" firstAttribute="leading" secondItem="5O0-EV-K1R" secondAttribute="leading" id="Ad3-gd-wg8"/>
-                            <constraint firstItem="5O0-EV-K1R" firstAttribute="bottom" secondItem="kBP-fR-9mu" secondAttribute="bottom" id="BKN-5m-S3l"/>
+                            <constraint firstAttribute="bottom" secondItem="kBP-fR-9mu" secondAttribute="bottom" id="BKN-5m-S3l"/>
                             <constraint firstItem="sRN-Fp-mgI" firstAttribute="centerX" secondItem="kBP-fR-9mu" secondAttribute="centerX" id="J6w-Pa-mI8"/>
                             <constraint firstItem="5O0-EV-K1R" firstAttribute="trailing" secondItem="kBP-fR-9mu" secondAttribute="trailing" id="L4W-dU-UKf"/>
                             <constraint firstItem="sRN-Fp-mgI" firstAttribute="centerY" secondItem="kBP-fR-9mu" secondAttribute="centerY" id="i37-3g-2Py"/>
-                            <constraint firstItem="kBP-fR-9mu" firstAttribute="top" secondItem="5O0-EV-K1R" secondAttribute="top" id="x2G-21-2W4"/>
+                            <constraint firstItem="kBP-fR-9mu" firstAttribute="top" secondItem="W9P-Ih-jmQ" secondAttribute="top" id="x2G-21-2W4"/>
                         </constraints>
                     </view>
                     <toolbarItems/>
@@ -936,6 +936,77 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="82C-Jj-OyW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-579.38931297709917" y="1637.323943661972"/>
+        </scene>
+        <!--Set Album Name View Controller-->
+        <scene sceneID="GmR-nm-71E">
+            <objects>
+                <viewController storyboardIdentifier="SetAlbumNameViewController" id="Rzf-IO-wp0" customClass="SetAlbumNameViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="4TR-t7-g3l">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view alpha="0.75" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GRQ-Pv-sdi">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6CA-pi-86C">
+                                        <rect key="frame" x="0.0" y="59" width="53.666666666666664" height="34.333333333333343"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="취소">
+                                            <fontDescription key="titleFontDescription" type="system" pointSize="17"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="cancleButton:" destination="Rzf-IO-wp0" eventType="touchUpInside" id="bCf-yb-Ixa"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lrx-s2-Epd">
+                                        <rect key="frame" x="339.33333333333331" y="59" width="53.666666666666686" height="33.333333333333343"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="확인">
+                                            <fontDescription key="titleFontDescription" type="system" pointSize="17"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="confirmButton:" destination="Rzf-IO-wp0" eventType="touchUpInside" id="lhC-Fv-2xe"/>
+                                        </connections>
+                                    </button>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zF8-78-9Q7" userLabel="앨범 이름">
+                                        <rect key="frame" x="20" y="292.33333333333331" width="353" height="34"/>
+                                        <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="zF8-78-9Q7" secondAttribute="trailing" constant="20" id="LHC-YA-xIO"/>
+                                    <constraint firstItem="zF8-78-9Q7" firstAttribute="top" secondItem="Lrx-s2-Epd" secondAttribute="bottom" constant="200" id="Zmr-q1-iqv"/>
+                                    <constraint firstItem="zF8-78-9Q7" firstAttribute="leading" secondItem="GRQ-Pv-sdi" secondAttribute="leading" constant="20" id="xzl-pO-KDO"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="DNz-aZ-V7m"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="GRQ-Pv-sdi" secondAttribute="bottom" id="1Jv-rT-K71"/>
+                            <constraint firstItem="DNz-aZ-V7m" firstAttribute="top" secondItem="Lrx-s2-Epd" secondAttribute="top" id="5ZI-ph-VUb"/>
+                            <constraint firstItem="GRQ-Pv-sdi" firstAttribute="top" secondItem="4TR-t7-g3l" secondAttribute="top" id="FMn-Dk-94e"/>
+                            <constraint firstItem="DNz-aZ-V7m" firstAttribute="top" secondItem="6CA-pi-86C" secondAttribute="top" id="Nh5-pY-Lbf"/>
+                            <constraint firstItem="GRQ-Pv-sdi" firstAttribute="leading" secondItem="DNz-aZ-V7m" secondAttribute="leading" id="OWY-23-ctN"/>
+                            <constraint firstItem="DNz-aZ-V7m" firstAttribute="trailing" secondItem="GRQ-Pv-sdi" secondAttribute="trailing" id="SMl-Za-UHn"/>
+                            <constraint firstItem="DNz-aZ-V7m" firstAttribute="trailing" secondItem="Lrx-s2-Epd" secondAttribute="trailing" id="hw4-9u-MaY"/>
+                            <constraint firstItem="6CA-pi-86C" firstAttribute="leading" secondItem="DNz-aZ-V7m" secondAttribute="leading" id="oWi-H9-aWw"/>
+                        </constraints>
+                    </view>
+                    <toolbarItems/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="albumName" destination="zF8-78-9Q7" id="s66-Vi-1zk"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="gOn-L5-VYb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-579.38931297709917" y="2384.5070422535214"/>
         </scene>
     </scenes>
     <resources>

--- a/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeEditViewController+AlbumNameTextField.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeEditViewController+AlbumNameTextField.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+// - MARK: SetAlbumNameViewController
+class SetAlbumNameViewController: UIViewController {
+    
+    @IBOutlet weak var albumName: UITextField!
+    var editVC : HomeEditViewController!
+    
+    override func viewDidLoad() {
+        albumName.text = editVC.albumName.text
+        albumName.becomeFirstResponder()
+    }
+    
+    @IBAction func cancleButton(_ sender: Any) {
+        dismiss(animated: true)
+    }
+    
+    @IBAction func confirmButton(_ sender: Any) {
+        editVC.albumName.text = self.albumName.text
+        dismiss(animated: true)
+    }
+    
+    
+}
+

--- a/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeEditViewController.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeEditViewController.swift
@@ -27,6 +27,7 @@ class HomeEditViewController: UIViewController {
         // 초기 subview 설정 :: 새로 앨범을 만드는 경우
         coverImage.image = UIImage(systemName: "photo")
         albumName.placeholder = " 앨범 명을 입력하세요"
+        albumName.delegate = self
         coverImage.layer.cornerRadius = 10
         createButton.layer.cornerRadius = 10
         cancleButton.layer.cornerRadius = 10

--- a/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController+CollectionView.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController+CollectionView.swift
@@ -66,8 +66,8 @@ extension HomeScreenViewController: UICollectionViewDataSource{
         cell.callback1 = {
             if cell.firstButton.imageView?.image == UIImage(systemName: "plus"){
                 let editVC = self.storyboard?.instantiateViewController(withIdentifier: "HomeEditViewController") as! HomeEditViewController
-                editVC.modalPresentationStyle = .overCurrentContext
                 editVC.collectionViewInHome = self.collectionView
+                editVC.modalPresentationStyle = .overCurrentContext
                 self.present(editVC, animated: false)
             }
             else {
@@ -81,8 +81,8 @@ extension HomeScreenViewController: UICollectionViewDataSource{
         cell.callback2 = {
             if cell.secondButton.imageView?.image == UIImage(systemName: "plus"){
                 let editVC = self.storyboard?.instantiateViewController(withIdentifier: "HomeEditViewController") as! HomeEditViewController
-                editVC.modalPresentationStyle = .overCurrentContext
                 editVC.collectionViewInHome = self.collectionView
+                editVC.modalPresentationStyle = .overCurrentContext
                 self.present(editVC, animated: false)
             }
             else{

--- a/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController.swift
@@ -21,6 +21,7 @@ class HomeScreenViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
+        navigationController?.isToolbarHidden = true
     }
     
     // - MARK: viewWillDisappear :: view가 사라질 때

--- a/NostelgiAlbum/ImageFunc/ImageFunc.swift
+++ b/NostelgiAlbum/ImageFunc/ImageFunc.swift
@@ -1,4 +1,3 @@
-import Foundation
 import UIKit
 
 func saveImageToDocumentDirectory(imageName: String, image: UIImage, AlbumCoverName: String) {


### PR DESCRIPTION
## 작성 내용
1. TextField 글자 입력하는 View 추가
2. 제공 앨범 커버 + 커스텀 앨범 커버 (미완) 선택하는 Alert 추가
3. AlbumScreenView의 Tool bar 고정
4. HomeEditView blur view를 SuperView까지 확장

## 특이사항
1. 커스텀 앨범 커버를 만들 때, Picker View 가 제공하는 이미지 편집 비율이 1:1로 고정되어 있어서 새로운 편집 Library를 찾거나 새로운 방식을 고안해야 함.
-> 해당 Alert만 만들고 기능은 만들어지지 않은 상태이다.
