### PR TITLE
[2023/03/08]-album sharing시 중복된 앨범 이름 수정 프로세스 재설계 및 이미지 타입 변경/chopmozzi

### DIFF
--- a/NostelgiAlbum/AlbumRenameViewController.swift
+++ b/NostelgiAlbum/AlbumRenameViewController.swift
@@ -13,6 +13,7 @@ class AlbumRenameViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         albumTextField.text = albumCoverName
+        albumTextField.becomeFirstResponder()
     }
 
     @IBAction func checkButton(_ sender: Any) {
@@ -21,6 +22,7 @@ class AlbumRenameViewController: UIViewController {
         } else {
             //guard let shareVC = storyboard?.instantiateViewController(withIdentifier: "ShareViewController") as? ShareViewController else { return }
             shareVC.albumCoverName = albumTextField.text
+            shareVC.albumCoverText.text = albumTextField.text
             shareVC.loadingAlbumInfo()
             self.dismiss(animated: true)
         }

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
@@ -88,7 +88,7 @@ class AlbumEditViewController: UIViewController {
     }
     
     func transPic(_ picture : album) {
-        let totalPath = "\(picture.AlbumTitle)_\(picture.perAlbumIndex).png"
+        let totalPath = "\(picture.AlbumTitle)_\(picture.perAlbumIndex).jpeg"
         editPicture.setImage(loadImageFromDocumentDirectory(imageName: totalPath, albumTitle: picture.AlbumTitle)?.resize(newWidth: editPicture.frame.size.width, newHeight: editPicture.frame.size.height), for: .normal)
         editPicture.setTitle("", for: .normal)
         editName.text = picture.ImageName
@@ -102,7 +102,7 @@ class AlbumEditViewController: UIViewController {
             updPicture[picture!.perAlbumIndex - 1].ImageName = editName.text!
             updPicture[picture!.perAlbumIndex - 1].ImageText = editText.text!
         }
-        let totalPath = "\(picture!.AlbumTitle)_\(picture!.perAlbumIndex).png"
+        let totalPath = "\(picture!.AlbumTitle)_\(picture!.perAlbumIndex).jpeg"
         saveImageToDocumentDirectory(imageName: totalPath, image: (editPicture.imageView?.image!)!, AlbumCoverName: picture!.AlbumTitle)
     }
     func addPic() {
@@ -118,7 +118,7 @@ class AlbumEditViewController: UIViewController {
             realm.add(newPicture)
             data.first!.setNumberOfPictures(index)
         }
-        let totalPath = "\(newPicture.AlbumTitle)_\(newPicture.perAlbumIndex).png"
+        let totalPath = "\(newPicture.AlbumTitle)_\(newPicture.perAlbumIndex).jpeg"
         saveImageToDocumentDirectory(imageName: totalPath, image: (editPicture.imageView?.image!)!, AlbumCoverName: albumCoverName)
     }
     @IBAction func savePicture(_ sender: Any) {

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumPicViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumPicViewController.swift
@@ -13,7 +13,7 @@ class AlbumPicViewController: UIViewController {
         picName.text = picture.ImageName
         picText.text = picture.ImageText
         picImage.setTitle("", for: .normal)
-        let totalPath = "\(picture.AlbumTitle)_\(picture.perAlbumIndex)"
+        let totalPath = "\(picture.AlbumTitle)_\(picture.perAlbumIndex).jpeg"
         picImage.setImage(loadImageFromDocumentDirectory(imageName: totalPath, albumTitle: picture.AlbumTitle)?.resize(newWidth: picImage.frame.width, newHeight: (picImage.frame.height)), for: .normal)
         settingBtn.setTitle("", for: .normal)
         settingBtn.setImage(UIImage(systemName: "gearshape"), for: .normal)
@@ -39,7 +39,7 @@ class AlbumPicViewController: UIViewController {
     }
     @IBAction func zoomImage(_ sender: Any) {
         guard let zoomVC = self.storyboard?.instantiateViewController(withIdentifier: "ImageViewController") as? ImageViewController else { return }
-        let totalPath = "\(self.picture.AlbumTitle)_\(self.picture.perAlbumIndex)"
+        let totalPath = "\(self.picture.AlbumTitle)_\(self.picture.perAlbumIndex).jpeg"
         zoomVC.imageName = totalPath
         zoomVC.albumTitle = self.picture.AlbumTitle
         zoomVC.modalPresentationStyle = .overFullScreen

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumScreenCollectionViewCell.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumScreenCollectionViewCell.swift
@@ -76,7 +76,7 @@ class AlbumScreenCollectionViewCell: UICollectionViewCell {
     
     // - MARK: When the cell has picture data, configure func is called.
     func configure(_ albumInfo : album){
-        let totalPath = "\(albumInfo.AlbumTitle)_\(albumInfo.perAlbumIndex).png"
+        let totalPath = "\(albumInfo.AlbumTitle)_\(albumInfo.perAlbumIndex).jpeg"
         let image = loadImageFromDocumentDirectory(imageName: totalPath, albumTitle: albumInfo.AlbumTitle)
         // Reset cell's subview to reload the data of collection view in albumScreenViewController.
         reset()

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewGesture.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewGesture.swift
@@ -65,7 +65,7 @@ extension AlbumScreenViewController {
         let picturesInfo = realm.objects(albumsInfo.self).filter("id = \(picture.index)")
         let num = picture.perAlbumIndex
         guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {return}
-        let filePath = "\(picture.AlbumTitle)/\(picture.AlbumTitle)_\(picture.perAlbumIndex).png"
+        let filePath = "\(picture.AlbumTitle)/\(picture.AlbumTitle)_\(picture.perAlbumIndex).jpeg"
         let pictureDirectory = documentDirectory.appending(path: filePath)
         if FileManager.default.fileExists(atPath: pictureDirectory.path) {
             do {
@@ -87,8 +87,8 @@ extension AlbumScreenViewController {
                 try! realm.write{
                     pictures[index-1].perAlbumIndex -= 1
                 }
-                let updatePath = "\(pictures[index-1].AlbumTitle)/\(pictures[index-1].AlbumTitle)_\(index).png"
-                let originPath = "\(pictures[index-1].AlbumTitle)/\(pictures[index-1].AlbumTitle)_\(index + 1).png"
+                let updatePath = "\(pictures[index-1].AlbumTitle)/\(pictures[index-1].AlbumTitle)_\(index).jpeg"
+                let originPath = "\(pictures[index-1].AlbumTitle)/\(pictures[index-1].AlbumTitle)_\(index + 1).jpeg"
                 let originDirectory = documentDirectory.appending(path: originPath)
                 let updateDirectory = documentDirectory.appending(path: updatePath)
                 print("origin",originDirectory.path)

--- a/NostelgiAlbum/Base.lproj/Main.storyboard
+++ b/NostelgiAlbum/Base.lproj/Main.storyboard
@@ -501,67 +501,74 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HCt-Vc-6G7">
-                                <rect key="frame" x="216" y="523" width="54" height="35"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="확인">
-                                    <color key="baseForegroundColor" systemColor="labelColor"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="openInButtonTapped:" destination="0TT-Up-5Uc" eventType="touchUpInside" id="bkx-Cb-LQT"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="앨범을 추가할까요?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ejy-85-G61">
-                                <rect key="frame" x="16" y="371" width="353" height="20.333333333333314"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jhb-jk-2xB">
-                                <rect key="frame" x="120" y="523" width="54" height="35"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="취소">
-                                    <color key="baseForegroundColor" systemColor="labelColor"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="closeInButtonTapped:" destination="0TT-Up-5Uc" eventType="touchUpInside" id="yct-Ef-0vD"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bx-Gb-lg4">
-                                <rect key="frame" x="129" y="303" width="127" height="35"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Button">
-                                    <color key="baseBackgroundColor" red="0.40000003579999999" green="0.2941176593" blue="0.22745099660000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="changeAlbumName:" destination="0TT-Up-5Uc" eventType="touchUpInside" id="1Lq-N1-8Vz"/>
-                                </connections>
-                            </button>
+                            <view alpha="0.75" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UAo-bT-CIS">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NVM-H7-2sQ" userLabel="PopUpView">
+                                <rect key="frame" x="76" y="268" width="240" height="272"/>
+                                <subviews>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Xgd-QY-Y0J">
+                                        <rect key="frame" x="45" y="56" width="150" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jhb-jk-2xB">
+                                        <rect key="frame" x="45" y="207" width="54" height="35"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="취소">
+                                            <color key="baseForegroundColor" systemColor="labelColor"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="closeInButtonTapped:" destination="0TT-Up-5Uc" eventType="touchUpInside" id="yct-Ef-0vD"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="앨범을 추가할까요?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ejy-85-G61">
+                                        <rect key="frame" x="8" y="146.33333333333331" width="224" height="20"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HCt-Vc-6G7">
+                                        <rect key="frame" x="141" y="207" width="54" height="35"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="확인">
+                                            <color key="baseForegroundColor" systemColor="labelColor"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="openInButtonTapped:" destination="0TT-Up-5Uc" eventType="touchUpInside" id="bkx-Cb-LQT"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="Xgd-QY-Y0J" secondAttribute="trailing" constant="45" id="0LQ-vI-nKn"/>
+                                    <constraint firstItem="HCt-Vc-6G7" firstAttribute="leading" secondItem="Jhb-jk-2xB" secondAttribute="trailing" constant="42" id="1Sg-k5-NPM"/>
+                                    <constraint firstItem="Xgd-QY-Y0J" firstAttribute="leading" secondItem="NVM-H7-2sQ" secondAttribute="leading" constant="45" id="5La-Cf-iYV"/>
+                                    <constraint firstAttribute="bottom" secondItem="HCt-Vc-6G7" secondAttribute="bottom" constant="30" id="6wB-Sa-4aM"/>
+                                    <constraint firstItem="ejy-85-G61" firstAttribute="leading" secondItem="NVM-H7-2sQ" secondAttribute="leading" constant="8" id="JUH-f7-xVd"/>
+                                    <constraint firstItem="ejy-85-G61" firstAttribute="top" secondItem="Xgd-QY-Y0J" secondAttribute="bottom" constant="56.333333333333314" id="Lhv-1x-Ln8"/>
+                                    <constraint firstAttribute="trailing" secondItem="ejy-85-G61" secondAttribute="trailing" constant="8" id="RZ9-u2-vld"/>
+                                    <constraint firstAttribute="bottom" secondItem="Jhb-jk-2xB" secondAttribute="bottom" constant="30" id="SJF-qv-v0U"/>
+                                    <constraint firstItem="Xgd-QY-Y0J" firstAttribute="top" secondItem="NVM-H7-2sQ" secondAttribute="top" constant="56" id="WaC-9s-uGN"/>
+                                    <constraint firstItem="Jhb-jk-2xB" firstAttribute="leading" secondItem="NVM-H7-2sQ" secondAttribute="leading" constant="45" id="gCO-iy-TC6"/>
+                                    <constraint firstAttribute="trailing" secondItem="HCt-Vc-6G7" secondAttribute="trailing" constant="45" id="jlH-Hz-mzr"/>
+                                    <constraint firstItem="Jhb-jk-2xB" firstAttribute="top" secondItem="ejy-85-G61" secondAttribute="bottom" constant="40.666666666666742" id="tqV-XX-2Ke"/>
+                                    <constraint firstItem="HCt-Vc-6G7" firstAttribute="top" secondItem="ejy-85-G61" secondAttribute="bottom" constant="40.666666666666742" id="zlj-mc-2Z4"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="caf-Pt-DJ6"/>
-                        <color key="backgroundColor" red="0.72156864399999998" green="0.60784316059999999" blue="0.54509806630000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="ejy-85-G61" firstAttribute="top" secondItem="5bx-Gb-lg4" secondAttribute="bottom" constant="33" id="1ru-me-Pk0"/>
-                            <constraint firstItem="HCt-Vc-6G7" firstAttribute="top" secondItem="ejy-85-G61" secondAttribute="bottom" constant="131.66666666666669" id="3He-Oq-BLl"/>
-                            <constraint firstItem="caf-Pt-DJ6" firstAttribute="trailing" secondItem="5bx-Gb-lg4" secondAttribute="trailing" constant="137" id="8kq-5a-Tae"/>
-                            <constraint firstItem="Jhb-jk-2xB" firstAttribute="leading" secondItem="caf-Pt-DJ6" secondAttribute="leading" constant="120" id="96x-q6-kLx"/>
-                            <constraint firstItem="caf-Pt-DJ6" firstAttribute="trailing" secondItem="ejy-85-G61" secondAttribute="trailing" constant="24" id="Ald-zs-lzQ"/>
-                            <constraint firstItem="Jhb-jk-2xB" firstAttribute="top" secondItem="ejy-85-G61" secondAttribute="bottom" constant="131.66666666666669" id="Deh-0B-PFq"/>
-                            <constraint firstItem="caf-Pt-DJ6" firstAttribute="bottom" secondItem="Jhb-jk-2xB" secondAttribute="bottom" constant="260" id="Eco-1R-IvF"/>
-                            <constraint firstItem="caf-Pt-DJ6" firstAttribute="trailing" secondItem="HCt-Vc-6G7" secondAttribute="trailing" constant="123" id="UcS-uc-Fcl"/>
-                            <constraint firstItem="Jhb-jk-2xB" firstAttribute="width" secondItem="HCt-Vc-6G7" secondAttribute="width" id="XNc-Ih-1tH"/>
-                            <constraint firstItem="5bx-Gb-lg4" firstAttribute="top" secondItem="caf-Pt-DJ6" secondAttribute="top" constant="244" id="chm-2T-2sC"/>
-                            <constraint firstItem="Jhb-jk-2xB" firstAttribute="height" secondItem="HCt-Vc-6G7" secondAttribute="height" id="eaH-qW-CKi"/>
-                            <constraint firstItem="5bx-Gb-lg4" firstAttribute="leading" secondItem="caf-Pt-DJ6" secondAttribute="leading" constant="129" id="fVL-AN-Q5h"/>
-                            <constraint firstItem="ejy-85-G61" firstAttribute="leading" secondItem="caf-Pt-DJ6" secondAttribute="leading" constant="16" id="kNv-1C-aaK"/>
-                            <constraint firstItem="caf-Pt-DJ6" firstAttribute="trailing" secondItem="HCt-Vc-6G7" secondAttribute="trailing" constant="123" id="pYX-DV-bI8"/>
-                            <constraint firstItem="caf-Pt-DJ6" firstAttribute="bottom" secondItem="HCt-Vc-6G7" secondAttribute="bottom" constant="260" id="sok-nu-O3i"/>
-                            <constraint firstItem="HCt-Vc-6G7" firstAttribute="leading" secondItem="Jhb-jk-2xB" secondAttribute="trailing" constant="42" id="uN0-S3-dYP"/>
-                            <constraint firstItem="Jhb-jk-2xB" firstAttribute="centerY" secondItem="HCt-Vc-6G7" secondAttribute="centerY" id="xMt-r8-D9U"/>
+                            <constraint firstItem="caf-Pt-DJ6" firstAttribute="bottom" secondItem="NVM-H7-2sQ" secondAttribute="bottom" constant="278" id="12G-HU-M7l"/>
+                            <constraint firstItem="NVM-H7-2sQ" firstAttribute="top" secondItem="caf-Pt-DJ6" secondAttribute="top" constant="209" id="XuI-b8-iOm"/>
+                            <constraint firstItem="caf-Pt-DJ6" firstAttribute="trailing" secondItem="NVM-H7-2sQ" secondAttribute="trailing" constant="77" id="iOV-1m-Ute"/>
+                            <constraint firstItem="NVM-H7-2sQ" firstAttribute="leading" secondItem="caf-Pt-DJ6" secondAttribute="leading" constant="76" id="ox3-3i-999"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="albumButton" destination="5bx-Gb-lg4" id="Kuh-fP-mrm"/>
+                        <outlet property="albumCoverText" destination="Xgd-QY-Y0J" id="3vS-hT-hcb"/>
                         <outlet property="albumShareButton" destination="HCt-Vc-6G7" id="gfi-iQ-hOQ"/>
                     </connections>
                 </viewController>
@@ -577,47 +584,44 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LUv-pR-TM5">
-                                <rect key="frame" x="31" y="59" width="54" height="35"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="취소">
-                                    <color key="baseForegroundColor" systemColor="labelColor"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="closeButton:" destination="DqS-xC-Mew" eventType="touchUpInside" id="y81-ll-fXW"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GmM-Qi-fhw">
-                                <rect key="frame" x="313" y="59" width="54" height="35"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="확인">
-                                    <color key="baseForegroundColor" systemColor="labelColor"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="checkButton:" destination="DqS-xC-Mew" eventType="touchUpInside" id="lxn-k7-trO"/>
-                                </connections>
-                            </button>
-                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uxA-3j-XTz">
-                                <rect key="frame" x="109" y="331" width="175" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
+                            <view alpha="0.75" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="t05-bA-DsL">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GmM-Qi-fhw">
+                                        <rect key="frame" x="312" y="67" width="54" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="확인">
+                                            <color key="baseForegroundColor" systemColor="opaqueSeparatorColor"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="checkButton:" destination="DqS-xC-Mew" eventType="touchUpInside" id="lxn-k7-trO"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LUv-pR-TM5">
+                                        <rect key="frame" x="28" y="67" width="54" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="취소">
+                                            <color key="baseForegroundColor" systemColor="opaqueSeparatorColor"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="closeButton:" destination="DqS-xC-Mew" eventType="touchUpInside" id="y81-ll-fXW"/>
+                                        </connections>
+                                    </button>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uxA-3j-XTz">
+                                        <rect key="frame" x="109" y="233" width="175" height="34"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gxA-5D-bXz"/>
-                        <color key="backgroundColor" red="0.72156864399999998" green="0.60784316059999999" blue="0.54509806630000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                        <constraints>
-                            <constraint firstItem="gxA-5D-bXz" firstAttribute="bottom" secondItem="uxA-3j-XTz" secondAttribute="bottom" constant="453" id="Ate-vp-JW0"/>
-                            <constraint firstItem="gxA-5D-bXz" firstAttribute="bottom" secondItem="LUv-pR-TM5" secondAttribute="bottom" constant="724" id="Jmg-cc-2k1"/>
-                            <constraint firstItem="gxA-5D-bXz" firstAttribute="trailing" secondItem="GmM-Qi-fhw" secondAttribute="trailing" constant="26" id="SeL-X9-kZE"/>
-                            <constraint firstItem="uxA-3j-XTz" firstAttribute="leading" secondItem="gxA-5D-bXz" secondAttribute="leading" constant="109" id="SrX-A9-grP"/>
-                            <constraint firstItem="LUv-pR-TM5" firstAttribute="leading" secondItem="gxA-5D-bXz" secondAttribute="leading" constant="31" id="eZC-gd-Y8X"/>
-                            <constraint firstItem="uxA-3j-XTz" firstAttribute="top" secondItem="gxA-5D-bXz" secondAttribute="top" constant="272" id="ggz-Tg-dUj"/>
-                            <constraint firstItem="LUv-pR-TM5" firstAttribute="top" secondItem="gxA-5D-bXz" secondAttribute="top" id="hpC-ol-VTo"/>
-                            <constraint firstItem="GmM-Qi-fhw" firstAttribute="top" secondItem="gxA-5D-bXz" secondAttribute="top" id="hyQ-F1-Xtd"/>
-                            <constraint firstItem="gxA-5D-bXz" firstAttribute="trailing" secondItem="uxA-3j-XTz" secondAttribute="trailing" constant="109" id="kgz-nb-6Yl"/>
-                            <constraint firstItem="GmM-Qi-fhw" firstAttribute="leading" secondItem="LUv-pR-TM5" secondAttribute="trailing" constant="228" id="sN6-JA-rAL"/>
-                            <constraint firstItem="gxA-5D-bXz" firstAttribute="bottom" secondItem="GmM-Qi-fhw" secondAttribute="bottom" constant="724" id="t2L-kT-1U6"/>
-                        </constraints>
                     </view>
                     <connections>
                         <outlet property="albumTextField" destination="uxA-3j-XTz" id="yFO-EY-BSv"/>

--- a/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeEditViewController+ButtonAction.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeEditViewController+ButtonAction.swift
@@ -116,8 +116,8 @@ extension HomeEditViewController {
             
             // 앨범 폴더 내의 사진 이름을 모두 변경
             for album in albumData {
-                let OldPicturePath = documentDirectory.appendingPathComponent(albumName.text!).appendingPathComponent("\(album.AlbumTitle)_\(album.perAlbumIndex).png")
-                let NewPicturePath = documentDirectory.appendingPathComponent(albumName.text!).appendingPathComponent("\(albumName.text!)_\(album.perAlbumIndex).png")
+                let OldPicturePath = documentDirectory.appendingPathComponent(albumName.text!).appendingPathComponent("\(album.AlbumTitle)_\(album.perAlbumIndex).jpeg")
+                let NewPicturePath = documentDirectory.appendingPathComponent(albumName.text!).appendingPathComponent("\(albumName.text!)_\(album.perAlbumIndex).jpeg")
                 do {
                     try FileManager.default.moveItem(at: OldPicturePath, to: NewPicturePath)
                     print("Move succcessful")

--- a/NostelgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
+++ b/NostelgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
@@ -16,7 +16,9 @@ extension HomeScreenViewController {
         shareVC.collectionViewInHome = collectionView
         
         // shareVC를 push
-        self.navigationController?.pushViewController(shareVC, animated: true)
+        //self.navigationController?.pushViewController(shareVC, animated: true)
+        shareVC.modalPresentationStyle = .overFullScreen
+        self.present(shareVC, animated: true)
     }
     
 }

--- a/NostelgiAlbum/ImageFunc/ImageFunc.swift
+++ b/NostelgiAlbum/ImageFunc/ImageFunc.swift
@@ -11,6 +11,7 @@ func saveImageToDocumentDirectory(imageName: String, image: UIImage, AlbumCoverN
 
     // 3. 이미지 압축(image.pngData())
     // 압축할거면 jpegData로~(0~1 사이 값)
+    // 2023/03/08 pngData -> jpegData
     guard let data = changedImage.jpegData(compressionQuality: 1) else {
         print("압축이 실패했습니다.")
         return

--- a/NostelgiAlbum/ImageFunc/ImageFunc.swift
+++ b/NostelgiAlbum/ImageFunc/ImageFunc.swift
@@ -12,7 +12,7 @@ func saveImageToDocumentDirectory(imageName: String, image: UIImage, AlbumCoverN
 
     // 3. 이미지 압축(image.pngData())
     // 압축할거면 jpegData로~(0~1 사이 값)
-    guard let data = changedImage.pngData() else {
+    guard let data = changedImage.jpegData(compressionQuality: 1) else {
         print("압축이 실패했습니다.")
         return
     }

--- a/NostelgiAlbum/ShareFunc.swift
+++ b/NostelgiAlbum/ShareFunc.swift
@@ -35,9 +35,9 @@ func zipAlbumDirectory(AlbumCoverName: String) -> URL? {
         print("Something went wrong")
     }
     do {
-        try FileManager.default.removeItem(at: dirURL.appendingPathComponent("\(AlbumCoverName)imageNameInfo.txt"))
-        try FileManager.default.removeItem(at: dirURL.appendingPathComponent("\(AlbumCoverName)imageTextInfo.txt"))
-        try FileManager.default.removeItem(at: dirURL.appendingPathComponent("\(AlbumCoverName)Info.txt"))
+        try FileManager.default.removeItem(at: dirURL.appendingPathComponent("\(AlbumCoverName)_imageNameInfo.txt"))
+        try FileManager.default.removeItem(at: dirURL.appendingPathComponent("\(AlbumCoverName)_imageTextInfo.txt"))
+        try FileManager.default.removeItem(at: dirURL.appendingPathComponent("\(AlbumCoverName)_Info.txt"))
     } catch {
         print("Error remove txt file")
     }

--- a/NostelgiAlbum/ShareFunc.swift
+++ b/NostelgiAlbum/ShareFunc.swift
@@ -191,6 +191,7 @@ func checkExistedAlbum(albumCoverName: String) -> Bool {
     return false
 }
 
+// - MARK: 앨범이름이 중복되었는지 확인하고 중복되었을 경우 앨범 디렉토리내 파일들 이름 변경
 func changeIfModifyName(albumCoverName: String) {
     guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
     let albumDir = documentDirectory.appendingPathComponent(albumCoverName)

--- a/NostelgiAlbum/ShareFunc.swift
+++ b/NostelgiAlbum/ShareFunc.swift
@@ -54,7 +54,7 @@ func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL) {
         try? data.write(to: zipURL)
         do {
             try Zip.unzipFile(zipURL, destination: zipURL.deletingPathExtension(), overwrite: true, password: nil)
-            checkModifyName(albumCoverName: AlbumCoverName)
+            changeIfModifyName(albumCoverName: AlbumCoverName)
             //zipURL == sandbox에서 documents내 zip
             try FileManager.default.removeItem(at: zipURL)
             //filePath == simulator의 경우 tmp/com....NostelgiAlbum-Inbox
@@ -191,7 +191,7 @@ func checkExistedAlbum(albumCoverName: String) -> Bool {
     return false
 }
 
-func checkModifyName(albumCoverName: String) {
+func changeIfModifyName(albumCoverName: String) {
     guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
     let albumDir = documentDirectory.appendingPathComponent(albumCoverName)
     let files: [URL]
@@ -209,3 +209,4 @@ func checkModifyName(albumCoverName: String) {
         print("files error")
     }
 }
+

--- a/NostelgiAlbum/ShareViewController.swift
+++ b/NostelgiAlbum/ShareViewController.swift
@@ -7,12 +7,12 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
     var collectionViewInHome : UICollectionView!
     var existedAlbum : Bool!
     var albumCoverName : String!
-    @IBOutlet weak var albumButton: UIButton!
+    @IBOutlet weak var albumCoverText: UITextField!
     override func viewDidLoad() {
         super.viewDidLoad()
         albumCoverName = filePath?.deletingPathExtension().lastPathComponent
-        albumButton.setTitle(albumCoverName, for: .normal)
-        albumButton.setImage(UIImage(systemName: "pencil"), for: .normal)
+        albumCoverText.text = albumCoverName
+        albumCoverText.delegate = self
         loadingAlbumInfo()
     }
     
@@ -24,7 +24,8 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
             importAlbumInfo(albumCoverName: albumCoverName)
             //album reload
             collectionViewInHome.reloadData()
-            self.navigationController?.popViewController(animated: true)
+            //self.navigationController?.popViewController(animated: true)
+            self.dismiss(animated: true)
         } else {
             let textAlert = UIAlertController(title: "중복된 이름", message: "이미 존재하는 앨범입니다. 이름을 바꿔주세요.", preferredStyle: UIAlertController.Style.alert)
             present(textAlert, animated: true){
@@ -58,5 +59,19 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
         
     @objc func didTappedOutside(_ sender: UITapGestureRecognizer) {
         dismiss(animated: true, completion: nil)
+    }
+    
+}
+
+extension ShareViewController: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        guard let renameVC = self.storyboard?.instantiateViewController(withIdentifier: "AlbumRenameViewController") as? AlbumRenameViewController else { return }
+        renameVC.albumCoverName = albumCoverName
+        renameVC.filePath = filePath
+        renameVC.shareVC = self
+//        renameVC.modalPresentationStyle = .overFullScreen
+        renameVC.modalPresentationStyle = .currentContext
+        renameVC.modalTransitionStyle = .crossDissolve
+        self.present(renameVC, animated: true)
     }
 }

--- a/NostelgiAlbum/ShareViewController.swift
+++ b/NostelgiAlbum/ShareViewController.swift
@@ -7,12 +7,13 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
     var collectionViewInHome : UICollectionView!
     var existedAlbum : Bool!
     var albumCoverName : String!
+    // 기존 button이었던 object를 Textfield로 변경
     @IBOutlet weak var albumCoverText: UITextField!
     override func viewDidLoad() {
         super.viewDidLoad()
         albumCoverName = filePath?.deletingPathExtension().lastPathComponent
         albumCoverText.text = albumCoverName
-        albumCoverText.delegate = self
+        albumCoverText.delegate = self //textfield 클릭 시 다른 뷰로 전환되는 delegate 추가
         loadingAlbumInfo()
     }
     
@@ -62,7 +63,7 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
     }
     
 }
-
+// -MARK: shareView에서 textfield 클릭 시 앨범 이름을 변경하는 AlbumRenameViewController를 present
 extension ShareViewController: UITextFieldDelegate {
     func textFieldDidBeginEditing(_ textField: UITextField) {
         guard let renameVC = self.storyboard?.instantiateViewController(withIdentifier: "AlbumRenameViewController") as? AlbumRenameViewController else { return }


### PR DESCRIPTION
## 작성 내용
shareViewController와 albumRenameViewController의 화면 present 방식을 modal로 변경했습니다(shareView는 기존에 push로 화면을 띄었음).
앨범의 이름을 표기하는 부분을 button에서 textField로 변경함과 동시에 textField의 delegate를 추가하였습니다(HomeScreen에서 앨범 수정 방식과 동일).
앨범 공유시의 화면을 앨범을 추가, 변경할 때의 화면과 유사하게 구성하였습니다.
이미지를 저장할 때 pngData에서 jpegData로 변경했습니다(compressionQuality == 1)
이에 따른 이미지를 저장하거나 불러올 때의 path에 .jpeg를 다 달아주었습니다.

## 특이사항
어플리케이션 테스트 중에 확인한 사항인데 디렉토리를 압축할 때 용량이 작은 경우(상한이 어딘지는 모르겠음) 압축 전 용량과 압축 후 용량이 같은 것을 확인했습니다.