### PR TITLE
[2023/03/19] - AlbumEditViewController & AlbumPicViewController CropVC 추가 / jeonmmingu

### DIFF
--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumPicViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumPicViewController.swift
@@ -9,18 +9,112 @@ class AlbumPicViewController: UIViewController {
     var picture: album!
     var collectionViewInAlbum : UICollectionView!
     
+    var width: CGFloat?
+    var height: CGFloat?
+    
+    var consArray: [NSLayoutConstraint]?
+    var newConsArray: [NSLayoutConstraint]?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        picName.text = picture.ImageName
-        picText.text = picture.ImageText
-        picImage.setTitle("", for: .normal)
-        let totalPath = "\(picture.AlbumTitle)_\(picture.perAlbumIndex).jpeg"
-        picImage.setImage(loadImageFromDocumentDirectory(imageName: totalPath, albumTitle: picture.AlbumTitle)?.resize(newWidth: picImage.frame.width, newHeight: (picImage.frame.height)), for: .normal)
-        settingBtn.setTitle("", for: .normal)
-        settingBtn.setImage(UIImage(systemName: "gearshape"), for: .normal)
+        setupSubviews()
+        
         let swipeRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(exitSwipe(_:)))
         swipeRecognizer.direction = .down
         self.view.addGestureRecognizer(swipeRecognizer)
+    }
+    
+    func setupSubviews() {
+        // set settingBtn
+        settingBtn.translatesAutoresizingMaskIntoConstraints = false
+        settingBtn.setTitle("", for: .normal)
+        settingBtn.setImage(UIImage(systemName: "gearshape"), for: .normal)
+        
+        // set picImage
+        picImage.translatesAutoresizingMaskIntoConstraints = false
+        picImage.setTitle("", for: .normal)
+        picImage.backgroundColor = .systemGray6
+        picImage.layer.cornerRadius = 10.0
+        
+        let totalPath = "\(picture.AlbumTitle)_\(picture.perAlbumIndex).jpeg"
+        
+        if let image = loadImageFromDocumentDirectory(imageName: totalPath, albumTitle: picture.AlbumTitle) {
+            if image.size.height > image.size.width {
+                width = UIScreen.main.bounds.width - 30
+                let remainder = Int(width!) % 3
+                if remainder != 0 {
+                    width = width! - CGFloat(remainder)
+                }
+                height = width! / 3 * 4
+            } else {
+                width = UIScreen.main.bounds.width - 40
+                let remainder = Int(width!) % 4
+                if remainder != 0 {
+                    width = width! - CGFloat(remainder)
+                }
+                height = width! / 4 * 3
+            }
+            picImage.setImage(resizeingImage(image: loadImageFromDocumentDirectory(imageName: totalPath, albumTitle: picture.AlbumTitle)!, width: Int(width!), height: Int(height!)), for: .normal)
+        }
+//        picImage.setImage(loadImageFromDocumentDirectory(imageName: totalPath, albumTitle: picture.AlbumTitle)?.resize(newWidth: picImage.frame.width, newHeight: (picImage.frame.height)), for: .normal)
+        
+        // set picName
+        picName.translatesAutoresizingMaskIntoConstraints = false
+        picName.text = picture.ImageName
+        
+        // set picText
+        picText.translatesAutoresizingMaskIntoConstraints = false
+        picText.text = picture.ImageText
+        
+        consArray = [
+            settingBtn.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            settingBtn.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -15),
+            settingBtn.heightAnchor.constraint(equalToConstant: 30),
+            settingBtn.widthAnchor.constraint(equalToConstant: 50),
+            
+            picImage.topAnchor.constraint(equalTo: settingBtn.bottomAnchor, constant: 10),
+            picImage.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            picImage.widthAnchor.constraint(equalToConstant: width!),
+            picImage.heightAnchor.constraint(equalToConstant: height!),
+            
+            picName.topAnchor.constraint(equalTo: picImage.bottomAnchor, constant: 10),
+            picName.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            picName.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            picName.heightAnchor.constraint(equalToConstant: 35),
+            
+            picText.topAnchor.constraint(equalTo: picName.bottomAnchor, constant: 10),
+            picText.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            picText.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            picText.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+        ]
+        newConsArray = [
+            settingBtn.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            settingBtn.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -15),
+            settingBtn.heightAnchor.constraint(equalToConstant: 30),
+            settingBtn.widthAnchor.constraint(equalToConstant: 50),
+            
+            picImage.topAnchor.constraint(equalTo: settingBtn.bottomAnchor, constant: 50),
+            picImage.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            picImage.widthAnchor.constraint(equalToConstant: width!),
+            picImage.heightAnchor.constraint(equalToConstant: height!),
+            
+            picName.topAnchor.constraint(equalTo: picImage.bottomAnchor, constant: 10),
+            picName.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            picName.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            picName.heightAnchor.constraint(equalToConstant: 35),
+            
+            picText.topAnchor.constraint(equalTo: picName.bottomAnchor, constant: 10),
+            picText.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            picText.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            picText.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -60)
+        ]
+        
+        if height! > width! {
+            NSLayoutConstraint.activate(consArray!)
+        } else {
+            NSLayoutConstraint.activate(newConsArray!)
+        }
+        
     }
     
     @objc func exitSwipe(_ sender :UISwipeGestureRecognizer){

--- a/NostelgiAlbum/Base.lproj/Main.storyboard
+++ b/NostelgiAlbum/Base.lproj/Main.storyboard
@@ -274,20 +274,9 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x16-SJ-OeI">
                                 <rect key="frame" x="0.0" y="59" width="393" height="759"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pDz-rf-7Ho">
-                                        <rect key="frame" x="307" y="20" width="66" height="35"/>
-                                        <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="SAVE"/>
-                                        <connections>
-                                            <action selector="savePicture:" destination="qGg-ET-l2z" eventType="touchUpInside" id="QGf-y4-Ye2"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pul-iH-fuh">
-                                        <rect key="frame" x="10" y="75" width="373" height="450"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="450" id="zKh-Oh-Eby"/>
-                                        </constraints>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pul-iH-fuh">
+                                        <rect key="frame" x="10" y="65" width="373" height="450"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
@@ -295,13 +284,15 @@
                                             <action selector="addAlbumPicture:" destination="qGg-ET-l2z" eventType="touchUpInside" id="7Uo-YJ-iYr"/>
                                         </connections>
                                     </button>
-                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="사진제목" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="29r-LZ-69x">
-                                        <rect key="frame" x="20" y="525" width="353" height="34"/>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="사진제목" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="29r-LZ-69x">
+                                        <rect key="frame" x="20" y="535" width="353" height="34"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qd4-6a-Gz8">
-                                        <rect key="frame" x="20" y="579" width="353" height="160"/>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qd4-6a-Gz8">
+                                        <rect key="frame" x="20" y="589" width="353" height="150"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <color key="textColor" systemColor="labelColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -317,23 +308,21 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pDz-rf-7Ho">
+                                        <rect key="frame" x="336" y="21" width="49" height="31"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="저장">
+                                            <fontDescription key="titleFontDescription" type="system" pointSize="14"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="savePicture:" destination="qGg-ET-l2z" eventType="touchUpInside" id="QGf-y4-Ye2"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" red="0.80000000000000004" green="0.81960784310000001" blue="0.93333333330000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <gestureRecognizers/>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="pul-iH-fuh" secondAttribute="trailing" constant="10" id="26Y-9k-Ra3"/>
-                                    <constraint firstAttribute="bottom" secondItem="qd4-6a-Gz8" secondAttribute="bottom" constant="20" id="89g-A3-uU6"/>
-                                    <constraint firstItem="pDz-rf-7Ho" firstAttribute="top" secondItem="x16-SJ-OeI" secondAttribute="top" constant="20" id="Gne-fB-XuC"/>
-                                    <constraint firstItem="pul-iH-fuh" firstAttribute="top" secondItem="pDz-rf-7Ho" secondAttribute="bottom" constant="20" id="HJJ-XR-WoO"/>
-                                    <constraint firstItem="29r-LZ-69x" firstAttribute="leading" secondItem="x16-SJ-OeI" secondAttribute="leading" constant="20" id="JHw-Lo-L7z"/>
-                                    <constraint firstAttribute="trailing" secondItem="pDz-rf-7Ho" secondAttribute="trailing" constant="20" id="Owy-pt-nI0"/>
-                                    <constraint firstItem="29r-LZ-69x" firstAttribute="top" secondItem="pul-iH-fuh" secondAttribute="bottom" id="RAk-Xd-hWN"/>
-                                    <constraint firstItem="qd4-6a-Gz8" firstAttribute="leading" secondItem="x16-SJ-OeI" secondAttribute="leading" constant="20" id="WUI-tN-PZL"/>
-                                    <constraint firstAttribute="trailing" secondItem="qd4-6a-Gz8" secondAttribute="trailing" constant="20" id="d86-fS-KeU"/>
-                                    <constraint firstItem="pul-iH-fuh" firstAttribute="leading" secondItem="x16-SJ-OeI" secondAttribute="leading" constant="10" id="fhX-cN-hoj"/>
-                                    <constraint firstItem="qd4-6a-Gz8" firstAttribute="top" secondItem="29r-LZ-69x" secondAttribute="bottom" constant="20" id="v58-rc-sKD"/>
-                                    <constraint firstAttribute="trailing" secondItem="29r-LZ-69x" secondAttribute="trailing" constant="20" id="x6H-qL-LYX"/>
-                                </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fG4-ly-ScL" userLabel="Bottom">
                                 <rect key="frame" x="0.0" y="813" width="393" height="5"/>
@@ -365,6 +354,7 @@
                         <outlet property="editName" destination="29r-LZ-69x" id="I9p-eu-dMN"/>
                         <outlet property="editPicture" destination="pul-iH-fuh" id="xvV-8b-Emc"/>
                         <outlet property="editText" destination="qd4-6a-Gz8" id="LcF-Vj-Iee"/>
+                        <outlet property="saveButton" destination="pDz-rf-7Ho" id="zvr-nF-2d8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UPA-Ui-UH1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -382,28 +372,17 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="blZ-Tc-pwX">
                                 <rect key="frame" x="0.0" y="59" width="393" height="759"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DJL-vM-fOY">
-                                        <rect key="frame" x="20" y="525" width="353" height="34"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U9I-5N-ooA">
+                                        <rect key="frame" x="20" y="587" width="353" height="152"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="34" id="HXh-r9-FAY"/>
-                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U9I-5N-ooA">
-                                        <rect key="frame" x="20" y="579" width="353" height="160"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="160" id="gbf-Vc-MUk"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iX7-Vq-biM">
-                                        <rect key="frame" x="298" y="20" width="75" height="35"/>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iX7-Vq-biM">
+                                        <rect key="frame" x="298" y="20" width="75" height="34.333333333333343"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
@@ -411,11 +390,9 @@
                                             <action selector="settingPicture:" destination="8u0-KJ-518" eventType="touchUpInside" id="cCF-2i-w4t"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="izs-d9-9Yf">
-                                        <rect key="frame" x="10" y="75" width="373" height="450"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="450" id="di3-Ug-teD"/>
-                                        </constraints>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="izs-d9-9Yf">
+                                        <rect key="frame" x="20" y="62" width="353" height="452"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
@@ -443,22 +420,18 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" ambiguous="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DJL-vM-fOY">
+                                        <rect key="frame" x="20" y="533" width="353" height="34"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="34" id="HXh-r9-FAY"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" red="0.80000000000000004" green="0.81960784310000001" blue="0.93333333330000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <constraints>
-                                    <constraint firstItem="U9I-5N-ooA" firstAttribute="top" secondItem="DJL-vM-fOY" secondAttribute="bottom" constant="20" id="3A4-XB-8TQ"/>
-                                    <constraint firstItem="DJL-vM-fOY" firstAttribute="leading" secondItem="blZ-Tc-pwX" secondAttribute="leading" constant="20" id="BT3-JU-GHg"/>
-                                    <constraint firstAttribute="trailing" secondItem="izs-d9-9Yf" secondAttribute="trailing" constant="10" id="CK4-k3-H94"/>
-                                    <constraint firstAttribute="bottom" secondItem="U9I-5N-ooA" secondAttribute="bottom" constant="20" id="Eqg-xg-p74"/>
-                                    <constraint firstItem="iX7-Vq-biM" firstAttribute="top" secondItem="blZ-Tc-pwX" secondAttribute="top" constant="20" id="KcH-AX-LhC"/>
-                                    <constraint firstItem="izs-d9-9Yf" firstAttribute="leading" secondItem="blZ-Tc-pwX" secondAttribute="leading" constant="10" id="Mca-ZB-ULX"/>
-                                    <constraint firstItem="U9I-5N-ooA" firstAttribute="leading" secondItem="blZ-Tc-pwX" secondAttribute="leading" constant="20" id="PD8-6b-c5o"/>
-                                    <constraint firstItem="DJL-vM-fOY" firstAttribute="top" secondItem="izs-d9-9Yf" secondAttribute="bottom" id="Qoh-nx-Ryf"/>
-                                    <constraint firstAttribute="trailing" secondItem="DJL-vM-fOY" secondAttribute="trailing" constant="20" id="TkY-sM-Xf2"/>
-                                    <constraint firstItem="izs-d9-9Yf" firstAttribute="top" secondItem="iX7-Vq-biM" secondAttribute="bottom" constant="20" id="h6y-LW-pob"/>
-                                    <constraint firstAttribute="trailing" secondItem="U9I-5N-ooA" secondAttribute="trailing" constant="20" id="iNE-WU-Cak"/>
-                                    <constraint firstAttribute="trailing" secondItem="iX7-Vq-biM" secondAttribute="trailing" constant="20" id="xit-Kv-Kvu"/>
-                                </constraints>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vZA-BX-owM"/>


### PR DESCRIPTION
## 작성 내용
1. AlbumEditViewController에서 PickerView에서 CropVC로 넘어가는 코드 작성
1-1. CropVC의 비율을 4:3, 3:4 두 가지로 구현
1-2. 잘린 비율에 따라 AlbumEditViewController의 Constraint를 변경
1-3. `4:3`: 가로가 긴 view에 맞춘 Constraint, `3:4`: 세로가 긴 view에 맞춘 Constraint
2. AlbumPicViewController에서 사진을 띄울 때 가로 세로 비율에 따라 Constraint를 조정
2-1. AlbumPicViewController에서 EditView로 넘어갈 때 `transPic()`함수를 거치는데 여기서 기존 사진의 가로 세로 비율에 따라 띄워주는 방식으로 구현

## 특이사항
1. AlbumPicView에서 `gear icon`을 선택하여 AlbumEditViewController로 넘어가서 내용을 변경한 경우 `변경 내용이 바로 반영되지 않는 오류`가 존재한다.