### PR TITLE
[2023/04/25] - Add RealmDB HomeSetting object & Home Setting - Theme Color Button Add & ThemeColorFunc, ThemeColorSet Add / jeonmmingu

### DIFF
--- a/NostelgiAlbum.xcodeproj/project.pbxproj
+++ b/NostelgiAlbum.xcodeproj/project.pbxproj
@@ -10,8 +10,10 @@
 		6E40494444D284B57AB22A17 /* Pods_NostelgiAlbumTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD45D2E351EE192C1D87DB8D /* Pods_NostelgiAlbumTests.framework */; };
 		8002F65328EE905B00E9913D /* HomeScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002F65228EE905B00E9913D /* HomeScreenViewController.swift */; };
 		8002F65528EE9D1800E9913D /* HomeScreenCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */; };
-		8006D02229ED528300389292 /* HomeSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006D02129ED528300389292 /* HomeSettingViewController.swift */; };
+		8006D02229ED528300389292 /* HomeiCloudSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006D02129ED528300389292 /* HomeiCloudSettingViewController.swift */; };
 		8020034B290FBB9200FCD54F /* AlbumScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8020034A290FBB9200FCD54F /* AlbumScreenViewController.swift */; };
+		8026146E29F785AD00CB9543 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8026146D29F785AD00CB9543 /* SettingViewController.swift */; };
+		8026147029F78B5200CB9543 /* HomeSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8026146F29F78B5200CB9543 /* HomeSettingViewController.swift */; };
 		804C7E8E295835D200C63880 /* ImageFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804C7E8D295835D200C63880 /* ImageFunc.swift */; };
 		806A653E293873C80054FAEF /* HomeEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806A653D293873C80054FAEF /* HomeEditViewController.swift */; };
 		807A193C29312CEF00BC434B /* RealmClassFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807A193B29312CEE00BC434B /* RealmClassFunc.swift */; };
@@ -33,6 +35,8 @@
 		80C56D18298CE5360063688F /* HomeScreenViewController+CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C56D17298CE5360063688F /* HomeScreenViewController+CollectionView.swift */; };
 		80C8C86C29DE92C300A9F01F /* AlbumEditViewController+ButtonAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C8C86B29DE92C300A9F01F /* AlbumEditViewController+ButtonAction.swift */; };
 		80C8C86E29DE935700A9F01F /* PickerImageController+CropViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C8C86D29DE935700A9F01F /* PickerImageController+CropViewController.swift */; };
+		80D580E729F79BFD00EF65C9 /* ThemeColorFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D580E629F79BFD00EF65C9 /* ThemeColorFunc.swift */; };
+		80D580E929F79C9E00EF65C9 /* ThemeColorSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D580E829F79C9E00EF65C9 /* ThemeColorSet.swift */; };
 		80DF50AE290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DF50AD290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift */; };
 		80FE482729B0832000FD0D6A /* SetAlbumNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FE482629B0832000FD0D6A /* SetAlbumNameViewController.swift */; };
 		831A04D8295EBDCA009D26A0 /* AlbumPicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831A04D7295EBDCA009D26A0 /* AlbumPicViewController.swift */; };
@@ -79,8 +83,10 @@
 		6E5DCC93F7BDA1B362378A7C /* Pods-NostelgiAlbum.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NostelgiAlbum.release.xcconfig"; path = "Target Support Files/Pods-NostelgiAlbum/Pods-NostelgiAlbum.release.xcconfig"; sourceTree = "<group>"; };
 		8002F65228EE905B00E9913D /* HomeScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenViewController.swift; sourceTree = "<group>"; };
 		8002F65428EE9D1800E9913D /* HomeScreenCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenCollectionViewCell.swift; sourceTree = "<group>"; };
-		8006D02129ED528300389292 /* HomeSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSettingViewController.swift; sourceTree = "<group>"; };
+		8006D02129ED528300389292 /* HomeiCloudSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeiCloudSettingViewController.swift; sourceTree = "<group>"; };
 		8020034A290FBB9200FCD54F /* AlbumScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumScreenViewController.swift; sourceTree = "<group>"; };
+		8026146D29F785AD00CB9543 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
+		8026146F29F78B5200CB9543 /* HomeSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSettingViewController.swift; sourceTree = "<group>"; };
 		804C7E8D295835D200C63880 /* ImageFunc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFunc.swift; sourceTree = "<group>"; };
 		806A653D293873C80054FAEF /* HomeEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeEditViewController.swift; sourceTree = "<group>"; };
 		807A193B29312CEE00BC434B /* RealmClassFunc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmClassFunc.swift; sourceTree = "<group>"; };
@@ -106,6 +112,8 @@
 		80C56D17298CE5360063688F /* HomeScreenViewController+CollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeScreenViewController+CollectionView.swift"; sourceTree = "<group>"; };
 		80C8C86B29DE92C300A9F01F /* AlbumEditViewController+ButtonAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlbumEditViewController+ButtonAction.swift"; sourceTree = "<group>"; };
 		80C8C86D29DE935700A9F01F /* PickerImageController+CropViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PickerImageController+CropViewController.swift"; sourceTree = "<group>"; };
+		80D580E629F79BFD00EF65C9 /* ThemeColorFunc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorFunc.swift; sourceTree = "<group>"; };
+		80D580E829F79C9E00EF65C9 /* ThemeColorSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorSet.swift; sourceTree = "<group>"; };
 		80D80B5029ED78F7009612FA /* NostelgiAlbum.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NostelgiAlbum.entitlements; sourceTree = "<group>"; };
 		80DF50AD290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumScreenCollectionViewCell.swift; sourceTree = "<group>"; };
 		80FE482629B0832000FD0D6A /* SetAlbumNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAlbumNameViewController.swift; sourceTree = "<group>"; };
@@ -201,6 +209,7 @@
 				831A0520297A9B7A009D26A0 /* HomeScreenViewController */,
 				831A0522297A9BD7009D26A0 /* AlbumScreenViewController */,
 				831A0525297A9BFE009D26A0 /* ImageFunc */,
+				80D580E529F79BC400EF65C9 /* ThemeFunc */,
 				8094CA3128EDC65900E70F76 /* Info.plist */,
 				80D80B5029ED78F7009612FA /* NostelgiAlbum.entitlements */,
 			);
@@ -236,6 +245,15 @@
 			path = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		80D580E529F79BC400EF65C9 /* ThemeFunc */ = {
+			isa = PBXGroup;
+			children = (
+				80D580E629F79BFD00EF65C9 /* ThemeColorFunc.swift */,
+				80D580E829F79C9E00EF65C9 /* ThemeColorSet.swift */,
+			);
+			path = ThemeFunc;
+			sourceTree = "<group>";
+		};
 		831A051F297A9B6E009D26A0 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -263,7 +281,8 @@
 				806A653D293873C80054FAEF /* HomeEditViewController.swift */,
 				8092C3A2298CE6F0007FFEF3 /* HomeEditViewController+ButtonAction.swift */,
 				80FE482629B0832000FD0D6A /* SetAlbumNameViewController.swift */,
-				8006D02129ED528300389292 /* HomeSettingViewController.swift */,
+				8026146F29F78B5200CB9543 /* HomeSettingViewController.swift */,
+				8006D02129ED528300389292 /* HomeiCloudSettingViewController.swift */,
 			);
 			path = HomeDetailController;
 			sourceTree = "<group>";
@@ -305,6 +324,7 @@
 				831E744729A5286400D48D5C /* AlbumRenameViewController.swift */,
 				8080200D29E18B9700CECCB8 /* InfoTableViewController.swift */,
 				807FF50029260656005D9884 /* InfoTableViewCell.swift */,
+				8026146D29F785AD00CB9543 /* SettingViewController.swift */,
 			);
 			path = ToolBarController;
 			sourceTree = "<group>";
@@ -608,22 +628,26 @@
 				80C56D18298CE5360063688F /* HomeScreenViewController+CollectionView.swift in Sources */,
 				804C7E8E295835D200C63880 /* ImageFunc.swift in Sources */,
 				8080201029E3F4C800CECCB8 /* SetPictureNameViewController.swift in Sources */,
+				80D580E729F79BFD00EF65C9 /* ThemeColorFunc.swift in Sources */,
 				83E5D2B429E80410001C7DE0 /* ContentsCells.swift in Sources */,
 				807FF50129260656005D9884 /* InfoTableViewCell.swift in Sources */,
 				8080201229E3F4D300CECCB8 /* SetPictureDescriptionViewController.swift in Sources */,
 				83E5D2B229E80410001C7DE0 /* ContentsSearchViewController.swift in Sources */,
+				8026146E29F785AD00CB9543 /* SettingViewController.swift in Sources */,
 				831E7446299A7BDF00D48D5C /* AlbumDelegate+Layout.swift in Sources */,
 				8002F65328EE905B00E9913D /* HomeScreenViewController.swift in Sources */,
 				8002F65528EE9D1800E9913D /* HomeScreenCollectionViewCell.swift in Sources */,
 				83E5D2BB29E8E6AD001C7DE0 /* PageSearchViewSectionDeco.swift in Sources */,
-				8006D02229ED528300389292 /* HomeSettingViewController.swift in Sources */,
+				8006D02229ED528300389292 /* HomeiCloudSettingViewController.swift in Sources */,
 				80A6D645299A0BE600B2D657 /* ShareFunc.swift in Sources */,
 				83C615C8298B978D0018BBAF /* ShareViewController.swift in Sources */,
 				8094CA2428EDC65500E70F76 /* AppDelegate.swift in Sources */,
 				8092C3A5298CF1AA007FFEF3 /* CollectionView+ButtonAction.swift in Sources */,
+				80D580E929F79C9E00EF65C9 /* ThemeColorSet.swift in Sources */,
 				831A04DA295EC04C009D26A0 /* ImageViewController.swift in Sources */,
 				80DF50AE290FBF80009EE336 /* AlbumScreenCollectionViewCell.swift in Sources */,
 				806A653E293873C80054FAEF /* HomeEditViewController.swift in Sources */,
+				8026147029F78B5200CB9543 /* HomeSettingViewController.swift in Sources */,
 				8320291F295EA8E2001709E9 /* AlbumEditViewController.swift in Sources */,
 				8092C3A3298CE6F0007FFEF3 /* HomeEditViewController+ButtonAction.swift in Sources */,
 				83C615F629994CE30018BBAF /* ToolBarButtonAction.swift in Sources */,
@@ -808,11 +832,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = NostelgiAlbum/NostelgiAlbum.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8A6XY8WY2J;
+				DEVELOPMENT_TEAM = 8A6XY8WY2J;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NostelgiAlbum/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Please allow to use Camera";
@@ -831,7 +853,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.App-in-App-le.NostelgiAlbum";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App-in-App-le-Development";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -846,11 +867,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = NostelgiAlbum/NostelgiAlbum.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8A6XY8WY2J;
+				DEVELOPMENT_TEAM = 8A6XY8WY2J;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NostelgiAlbum/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Please allow to use Camera";
@@ -869,7 +888,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.App-in-App-le.NostelgiAlbum";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "App-in-App-le-Development";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDelegate+Layout.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDelegate+Layout.swift
@@ -32,6 +32,8 @@ extension AlbumScreenViewController: UICollectionViewDataSource{
                 cell.reset()
             }
         }
+        
+        cell.setThemeColor()
         return cell
     }
 }

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumEditViewController.swift
@@ -1,12 +1,18 @@
 import UIKit
+import RealmSwift
 
 class AlbumEditViewController: UIViewController {
+    
+    @IBOutlet weak var topLabel: UILabel!
+    @IBOutlet weak var bodyView: UIView!
+    @IBOutlet weak var bottomLabel: UILabel!
     
     @IBOutlet weak var saveButton: UIButton!
     @IBOutlet weak var editPicture: UIButton!
     @IBOutlet weak var editName: UITextField!
     @IBOutlet weak var editText: UITextView!
     
+    let realm = try! Realm()
     var collectionViewInAlbum : UICollectionView!
     var picVC : AlbumPicViewController?
     var index : Int!
@@ -35,6 +41,7 @@ class AlbumEditViewController: UIViewController {
         let swipeRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(exitSwipe(_:)))
         swipeRecognizer.direction = .down
         self.view.addGestureRecognizer(swipeRecognizer)
+        setThemeColor()
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?){

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumPicViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/AlbumPicViewController.swift
@@ -1,11 +1,16 @@
 import UIKit
+import RealmSwift
 
 class AlbumPicViewController: UIViewController {
 
+    @IBOutlet weak var topLabel: UILabel!
+    @IBOutlet weak var bottomLabel: UILabel!
+    @IBOutlet weak var bodyView: UIView!
     @IBOutlet weak var picName: UILabel!
     @IBOutlet weak var picText: UITextView!
     @IBOutlet weak var picImage: UIButton!
     @IBOutlet weak var settingBtn: UIButton!
+    let realm = try! Realm()
     var picture: album!
     var collectionViewInAlbum : UICollectionView!
     
@@ -18,7 +23,7 @@ class AlbumPicViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupSubviews()
-        
+        setThemeColor()
         let swipeRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(exitSwipe(_:)))
         swipeRecognizer.direction = .down
         self.view.addGestureRecognizer(swipeRecognizer)

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/ImageViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumDetailController/ImageViewController.swift
@@ -1,10 +1,12 @@
 import UIKit
+import RealmSwift
 
 class ImageViewController: UIViewController {
 
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var closeButton: UIButton!
+    let realm = try! Realm()
     var imageName: String?
     var albumTitle: String?
     
@@ -13,6 +15,7 @@ class ImageViewController: UIViewController {
         closeButton.setTitle("", for: .normal)
         closeButton.setImage(UIImage(systemName: "clear"), for: .normal)
         imageInit()
+        setThemeColor()
     }
     
     func imageInit() {

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumScreenCollectionViewCell.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumScreenCollectionViewCell.swift
@@ -1,8 +1,9 @@
 import UIKit
+import RealmSwift
 
 class AlbumScreenCollectionViewCell: UICollectionViewCell {
-    
-    // - MARK: Declare Class' Properties
+    // MARK: - Properties
+    let realm = try! Realm()
     // Cell 하위에 들어가는 하위 뷰 객체들
     var pictureImgButton : UIButton?
     var pictureLabel: UILabel?
@@ -18,7 +19,6 @@ class AlbumScreenCollectionViewCell: UICollectionViewCell {
     func setButton() {
         pictureImgButton!.translatesAutoresizingMaskIntoConstraints = false
         pictureImgButton!.setImage(UIImage(systemName: "plus"), for: .normal)
-        pictureImgButton!.backgroundColor = UIColor(red: 0.57, green: 0.58, blue: 0.67, alpha: 0.50)
         pictureImgButton!.layer.cornerRadius = 10
         pictureImgButton!.imageView!.layer.cornerRadius = 10
         pictureImgButton!.setTitle("", for: .normal)
@@ -101,8 +101,8 @@ class AlbumScreenCollectionViewCell: UICollectionViewCell {
         }
         // Set image and text.
         pictureLabel!.text = albumInfo.ImageText
-        pictureImgButton?.layer.borderWidth = 5
-        pictureImgButton?.layer.borderColor = UIColor.white.cgColor
+//        pictureImgButton?.layer.borderWidth = 5
+//        pictureImgButton?.layer.borderColor = UIColor.white.cgColor
     }
     
     // - MARK: The target action of pictureImgButton.

--- a/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/AlbumScreenViewController.swift
@@ -8,29 +8,38 @@ class AlbumScreenViewController: UIViewController {
     var delegate: PageDelegate?
     // collectionView setting
     @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet weak var topLabel: UILabel!
+    @IBOutlet weak var bottomLabel: UILabel!
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         collectionView.dataSource = self
         collectionView.delegate = self
+        
+        setThemeColor()
+        
         toolbarItems = makeToolbarItems()
         navigationController?.toolbar.tintColor = UIColor.label
         let pageNumButton = UIButton()
-        pageNumButton.setTitle("\(pageNum + 1) Page", for: .normal)
-        pageNumButton.titleLabel?.font = UIFont(name: "Bradley Hand", size: 20)
-        pageNumButton.setTitleColor(.black, for: .normal)
+        pageNumButton.setTitle("\(pageNum + 1) page", for: .normal)
+        pageNumButton.titleLabel?.font = UIFont(name: "Arial", size: 15)
+        pageNumButton.setTitleColor(.white, for: .normal)
         pageNumButton.titleLabel?.sizeToFit()
         pageNumButton.addTarget(self, action: #selector(pageButtonTapped), for: .touchUpInside)
         let titleName = UILabel()
         let albumName = realm.objects(albumCover.self).filter("id = \(coverIndex)").first?.albumName
         titleName.text = albumName
-        titleName.font = UIFont(name: "Bradley Hand", size: 18)
-        titleName.textColor = .black
+        titleName.font = UIFont(name: "Arial.bold", size: 18)
+        titleName.textColor = .white
         titleName.sizeToFit()
         
         navigationItem.titleView = titleName
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "chevron.left.square"), style: .plain, target: self, action: #selector(popToHome))
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .regular)
+        let backButtonImage = UIImage(systemName: "chevron.left", withConfiguration: imageConfig)?.withRenderingMode(.alwaysTemplate)
+        let backButton = UIBarButtonItem(image: backButtonImage, style: .plain, target: self, action: #selector(popToHome))
+        backButton.tintColor = UIColor.white
+        navigationItem.leftBarButtonItem = backButton
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: pageNumButton)
         let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(AlbumScreenViewController.respondToSwipeGesture(_:)))
         swipeRight.direction = UISwipeGestureRecognizer.Direction.right

--- a/NostelgiAlbum/AlbumScreenViewController/ToolBarController/InfoTableViewCell.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/ToolBarController/InfoTableViewCell.swift
@@ -1,7 +1,9 @@
 import UIKit
+import RealmSwift
 
 class InfoTableCell: UITableViewCell {
     // MARK: - Properties
+    let realm = try! Realm()
     var cellTitle: UILabel! = nil
     var cellDescription: UILabel! = nil
     

--- a/NostelgiAlbum/AlbumScreenViewController/ToolBarController/InfoTableViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/ToolBarController/InfoTableViewController.swift
@@ -25,6 +25,7 @@ class InfoTableViewController: UIViewController {
         loadData()
         setTableView()
         setTableViewHeader()
+        setThemeColor()
     }
     
 
@@ -46,7 +47,6 @@ class InfoTableViewController: UIViewController {
     
     func setTableView() {
         tableView = UITableView(frame: .zero, style: .insetGrouped)
-        tableView.backgroundColor = .systemGray6
         tableView.isScrollEnabled = false
         tableView.allowsSelection = false
         view.addSubview(tableView)
@@ -68,13 +68,15 @@ class InfoTableViewController: UIViewController {
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: header.frame.height))
         label.text = "앨범 정보"
         label.font = UIFont.boldSystemFont(ofSize: 18)
+        label.textColor = .black
         label.textAlignment = .center
         
         let button = UIButton(frame: CGRect(x: 0, y: 0, width: header.bounds.height * 2, height: header.bounds.height))
         button.setTitle(" 앨범", for: .normal)
         button.titleLabel?.font = UIFont(name: "Arial", size: 15)
-        button.setTitleColor(UIColor.systemBlue, for: .normal)
+        button.setTitleColor(UIColor.black, for: .normal)
         button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        button.tintColor = .black
         button.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
         
         header.addSubview(label)

--- a/NostelgiAlbum/AlbumScreenViewController/ToolBarController/SettingViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/ToolBarController/SettingViewController.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+class SettingViewController: UIViewController {
+    // MARK: - Properties
+    var tableView: UITableView! = nil
+    var tableCons: [NSLayoutConstraint]! = nil
+    var index: Int!
+    
+    
+    // MARK: - View Life Cycle
+    override func viewDidLoad() {
+        
+    }
+    
+    // MARK: - Methods
+    
+    
+}
+
+// RealmDB 내용 수정해야함
+// 글꼴
+// 첫 페이지 설정 (첫 페이지, 마지막 페이지, 중간에 나간 페이지)
+// 

--- a/NostelgiAlbum/HomeScreenViewController/CollectionView+ButtonAction.swift
+++ b/NostelgiAlbum/HomeScreenViewController/CollectionView+ButtonAction.swift
@@ -108,11 +108,13 @@ extension HomeScreenViewController {
     
     @IBAction func homeSettingButtonAction(_ sender: Any) {
         guard let homeSettingVC = self.storyboard?.instantiateViewController(withIdentifier: "HomeSettingViewController") as? HomeSettingViewController else { return }
-        homeSettingVC.collectionView = self.collectionView
+        homeSettingVC.homeScreenViewController = self
+        homeSettingVC.homeScreenCollectionView = collectionView
         
         // Present homeSettingVC
         homeSettingVC.modalPresentationStyle = .overCurrentContext
-        self.present(homeSettingVC, animated: false)
+        homeSettingVC.modalTransitionStyle = .crossDissolve
+        self.present(homeSettingVC, animated: true)
     }
     
     @objc private func didTappedOutside(_ sender: UITapGestureRecognizer) {

--- a/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeSettingViewController.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeSettingViewController.swift
@@ -4,7 +4,9 @@ import RealmSwift
 class HomeSettingViewController: UIViewController {
     // MARK: - Properties
     @IBOutlet weak var backgroundStackView: UIStackView!
-    var collectionView: UICollectionView!
+    let realm = try! Realm()
+    var homeScreenViewController: HomeScreenViewController! = nil
+    var homeScreenCollectionView: UICollectionView! = nil
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -19,251 +21,68 @@ class HomeSettingViewController: UIViewController {
         dismiss(animated: false)
     }
     
-    @IBAction func homeSettingButtonAction(_ sender: Any) {
+    
+    @IBAction func settingButtonAction(_ sender: Any) {
         dismiss(animated: false)
     }
     
-    @IBAction func backupButtonAction(_ sender: Any) {
-        // Set iCloudDocsURL Here & Do Nil Check
-        if let iCloudDocsURL = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("Documents") {
-            // Make albums' Nost file
-            let realm = try! Realm()
-            var localNostURL = [URL]()
-            var iCloudNostURL = [URL]()
-            let albumCoverInfos = realm.objects(albumCover.self)
-            if albumCoverInfos.isEmpty == true {
-                // Alert
-                // Notice Alert
-                let alert = UIAlertController(title: "저장할 앨범이 없습니다", message: "최소 한 개 이상의 앨범을 생성 후 백업을 진행해주세요", preferredStyle: .alert)
-                let okAction = UIAlertAction(title: "확인", style: .default) { action in
-                    self.dismiss(animated: false) {
-                        self.dismiss(animated: false)
-                    }
+    @IBAction func iCloudButtonAction(_ sender: Any) {
+        guard let homeSettingVC = self.storyboard?.instantiateViewController(withIdentifier: "HomeiCloudSettingViewController") as? HomeiCloudSettingViewController else { return }
+        
+        // Present homeSettingVC
+        homeSettingVC.modalPresentationStyle = .overCurrentContext
+        homeSettingVC.modalTransitionStyle = .crossDissolve
+        self.present(homeSettingVC, animated: true)
+    }
+    
+    @IBAction func colorSettingButtonAction(_ sender: Any) {
+        print("colorSettingButton Tapped!!")
+        
+        let colors = ["파란색": "blue", "갈색": "brown", "녹색" : "green"].sorted(by: <)
+        let alert = UIAlertController(title: "테마", message: "색상을 선택하세요 🎨", preferredStyle: .alert)
+        for color in colors {
+            print(color.key)
+            let action = UIAlertAction(title: color.key, style: .default) { action in
+                let homeSettingInfo = self.realm.objects(HomeSetting.self).first!
+                try! self.realm.write {
+                    homeSettingInfo.themeColor = color.value
                 }
-                alert.addAction(okAction)
-                present(alert, animated: true)
-                return
-            } else {
-                // Check File Path Exist Or Not
-                if !FileManager.default.fileExists(atPath: iCloudDocsURL.path, isDirectory: nil) {
-                    // Case File Path Doesn't Exist, Make Directory Here
-                    try? FileManager.default.createDirectory(at: iCloudDocsURL, withIntermediateDirectories: true, attributes: nil)
-                    print("DATA BACK UP :: CREATE iCLOUD DIRECTORY")
-                }
-                // BackUp
-                do {
-                    let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
-                    var message = String()
-                    if !contents.isEmpty {
-                        var Datas = [String]()
-                        for content in contents {
-                            Datas.append("앨범 명: \(content.replacingOccurrences(of: ".nost", with: ""))")
-                        }
-                        message = "기존 백업 데이터가 존재합니다! \n백업 진행 시, 이전 백업 데이터가 삭제되고 현재 앨범 정보가 저장됩니다.\n\n[이전 백업 데이터]\n\(Datas.joined(separator: "\n"))"
-                    } else {
-                        message = "이전 백업 데이터가 존재하지 않습니다."
-                    }
-                    let alert = UIAlertController(title: "백업", message: message, preferredStyle: .alert)
-                    let okAction = UIAlertAction(title: "확인", style: .default) { action in
-                        for albumCoverInfo in albumCoverInfos {
-                            if let newNostURL = zipAlbumDirectory(AlbumCoverName: albumCoverInfo.albumName) {
-                                localNostURL.append(newNostURL)
-                                iCloudNostURL.append(iCloudDocsURL.appendingPathComponent("\(albumCoverInfo.albumName).nost"))
-                            } else {
-                                // Alert or Error
-                                print("FileManager Error :: Cannot Find Document Directory Path in zipAlbumDirectory")
-                                return
-                            }
-                        }
-                        
-                        // 기존에 백업된 정보 전부 삭제
-                        do {
-                            let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
-                            for content in contents {
-                                do {
-                                    try FileManager.default.removeItem(at: iCloudDocsURL.appendingPathComponent(content))
-                                } catch {
-                                    print("ERROR :: iCloud remove error")
-                                }
-                            }
-                        } catch {
-                            print("ERROR :: FileManager Bring iCloud Document Path Error")
-                        }
-                        
-                        for index in 0...localNostURL.count - 1 {
-                            do {
-                                // Copy Local Directory File Contents To iCloud Driver
-                                try FileManager.default.copyItem(at: localNostURL[index], to: iCloudNostURL[index])
-                                // Delete Local Nost File
-                                try FileManager.default.removeItem(at: localNostURL[index])
-                                print("DATA BACK UP :: UPLOAD SUCCESS TO iCLOUD DRIVER")
-                            } catch let error as NSError {
-                                // Handling Exception Here When You Developing
-                                print("DATA BACK UP :: UPLOAD FAIL TO iCLOUD DRIVER \(error) ")
-                            }
-                        }
-                        
-                        let alert = UIAlertController(title: "백업 완료", message: "백업이 완료되었습니다.👻", preferredStyle: .alert)
-                        let okAction = UIAlertAction(title: "확인", style: .default) { action in
-                            self.dismiss(animated: false)
-                        }
-                        alert.addAction(okAction)
-                        self.present(alert, animated: true)
-                    }
-                    let cancleAction = UIAlertAction(title: "취소", style: .default) { action in
-                        alert.dismiss(animated: false)
-                    }
-                    alert.addAction(okAction)
-                    alert.addAction(cancleAction)
-                    present(alert, animated: false)
-                } catch {
-                    print("ERROR :: FileManager contentsOfDirectory")
-                }
+                self.homeScreenViewController.setThemeColor()
+                self.homeScreenCollectionView.reloadData()
+                
+                self.dismiss(animated: false)
             }
-        } else {
-            // Notice Alert
-            let alert = UIAlertController(title: "iCloud 연결이 필요합니다", message: "\n설정 - Apple ID - iCloud - 모두 보기 - NostelgiAlbum - 허용 ", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "확인", style: .default) { action in
-                alert.dismiss(animated: false)
+            switch color.value {
+            case "blue":
+                action.setValue(UIColor(red: 0.40, green: 0.40, blue: 0.85, alpha: 1.00), forKey: "titleTextColor")
+            case "brown":
+                action.setValue(UIColor.systemBrown, forKey: "titleTextColor")
+            case "green":
+                action.setValue(UIColor(red: 0.33, green: 0.64, blue: 0.55, alpha: 1.00), forKey: "titleTextColor")
+            default:
+                action.setValue(UIColor.black, forKey: "titleTextColor")
             }
-            alert.addAction(okAction)
-            present(alert, animated: true)
+            
+//            let attributedString = NSMutableAttributedString(string: color.key)
+//            attributedString.addAttribute(.font, value: UIFont.boldSystemFont(ofSize: 17), range: NSRange(location: 0, length: attributedString.length))
+//
+//            alert.setValue(attributedString, forKey: "attributedTitle")
+            
+            alert.addAction(action)
+        }
+        
+        // width constraint
+        let constraintWidth = NSLayoutConstraint(
+            item: alert.view!, attribute: NSLayoutConstraint.Attribute.width, relatedBy: NSLayoutConstraint.Relation.equal, toItem: nil, attribute:
+                NSLayoutConstraint.Attribute.notAnAttribute, multiplier: 1, constant: 200)
+        alert.view.addConstraint(constraintWidth)
+        
+        self.present(alert, animated: true) {
+            alert.view.superview?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.didTappedOutside(_:))))
         }
     }
     
-    @IBAction func recoverButtonAction(_ sender: Any) {
-        var AlbumDatas = [String]()
-        
-        if let iCloudDocsURL = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("Documents") {
-            // Success
-            // Notice Alert
-            do {
-                let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
-                if contents.isEmpty {
-                    let alert = UIAlertController(title: "백업 파일이 존재하지 않습니다", message: nil, preferredStyle: .alert)
-                    let okAction = UIAlertAction(title: "확인", style: .default) { action in
-                        alert.dismiss(animated: false)
-                    }
-                    alert.addAction(okAction)
-                    present(alert, animated: false)
-                    return
-                } else {
-                    AlbumDatas = contents
-                }
-            } catch {
-                print("ERROR :: FileManager contentsOfDirectory")
-            }
-        } else {
-            // Failed
-            // Notice Alert
-            let alert = UIAlertController(title: "iCloud 연결이 필요합니다", message: "\n설정 - Apple ID - iCloud - 모두 보기 - NostelgiAlbum - 허용 ", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "확인", style: .default) { action in
-                alert.dismiss(animated: false)
-            }
-            alert.addAction(okAction)
-            present(alert, animated: true)
-            return
-        }
-        
-        let alert = UIAlertController(title: "경고", message: "복원을 진행할 경우 \n현재 생성된 앨범 정보가 모두 삭제됩니다", preferredStyle: .alert)
-        let cancleAction = UIAlertAction(title: "취소", style: .default) { action in
-            alert.dismiss(animated: false)
-        }
-        let okAction = UIAlertAction(title: "확인", style: .default) { action in
-            var Datas = [String]()
-            for AlbumData in AlbumDatas {
-                Datas.append("앨범 명: \(AlbumData.replacingOccurrences(of: ".nost", with: ""))")
-            }
-            let message = "[백업 데이터]\n\(Datas.joined(separator: "\n"))"
-            
-            let alert = UIAlertController(title: "복원", message: "현재 생성된 앨범 정보를 삭제하고 복원을 진행하시겠습니까?\n(복원 완료 시, 어플이 종료됩니다.)\n\n\(message)", preferredStyle: .alert)
-            let cancleAction = UIAlertAction(title: "취소", style: .default) { action in
-                alert.dismiss(animated: false)
-            }
-            let confirmAction = UIAlertAction(title: "확인", style: .default) { action in
-                if let iCloudDocsURL = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("Documents") {
-                    // 기존 정보 삭제
-                    // Document 정보 삭제
-                    guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
-                    do {
-                        let contents = try FileManager.default.contentsOfDirectory(atPath: documentDirectory.path)
-                        for content in contents {
-                            if !content.hasPrefix("default") && !content.hasSuffix("Inbox") {
-                                print(content)
-                                do {
-                                    try FileManager.default.removeItem(at: documentDirectory.appendingPathComponent(content))
-                                } catch {
-                                    print("ERROR :: FileManager remove error")
-                                }
-                            }
-                        }
-                    } catch {
-                        print("ERROR :: FileManager Bring Document Path Error")
-                    }
-
-                    // RealmDB 정보 삭제
-                    let realm = try! Realm()
-                    let albumCover = realm.objects(albumCover.self)
-                    let album = realm.objects(album.self)
-                    let albumsInfo = realm.objects(albumsInfo.self)
-
-                    for albumCoverData in albumCover {
-                        do {
-                            try realm.write {
-                                realm.delete(albumCoverData)
-                            }
-                        } catch {
-                            print("ERROR :: Cannot delete albumCover data in realmDB")
-                        }
-                    }
-                    for albumData in album {
-                        do {
-                            try realm.write {
-                                realm.delete(albumData)
-                            }
-                        } catch {
-                            print("ERROR :: Cannot delete album data in realmDB")
-                        }
-                    }
-                    for albumsInfoData in albumsInfo {
-                        do {
-                            try realm.write {
-                                realm.delete(albumsInfoData)
-                            }
-                        } catch {
-                            print("ERROR :: Cannot delete albumsInfo data in realmDB")
-                        }
-                    }
-
-                    // unzip & import data
-                    do {
-                        let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
-                        print(contents)
-                        for content in contents {
-                            if content.hasSuffix(".nost") {
-                                let albumCoverName = content.replacingOccurrences(of: ".nost", with: "")
-                                let shareFilePath = iCloudDocsURL.appendingPathComponent(content)
-                                unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: shareFilePath)
-                                importAlbumInfo(albumCoverName: albumCoverName, useForShare: false)
-                            }
-                        }
-                        print("SUCESS :: Complete Recover!")
-                        UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                            exit(0)
-                        }
-                    } catch let error as NSError {
-                        // Handling Exception Here When You Developing
-                        print("TEST Error :: UPLOAD FAIL TO iCLOUD DRIVER \(error)")
-                    }
-                }
-            }
-            alert.addAction(confirmAction)
-            alert.addAction(cancleAction)
-            self.present(alert, animated: true)
-        }
-        alert.addAction(okAction)
-        alert.addAction(cancleAction)
-        present(alert, animated: true)
+    @objc private func didTappedOutside(_ sender: UITapGestureRecognizer) {
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeiCloudSettingViewController.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeDetailController/HomeiCloudSettingViewController.swift
@@ -1,0 +1,268 @@
+import UIKit
+import RealmSwift
+
+class HomeiCloudSettingViewController: UIViewController {
+    // MARK: - Properties
+    @IBOutlet weak var backgroundStackView: UIStackView!
+    
+    // MARK: - View Life Cycle
+    override func viewDidLoad() {
+        backgroundStackView.layer.cornerRadius = 15.0
+        backgroundStackView.layer.borderWidth = 2
+        backgroundStackView.layer.borderColor = UIColor.black.cgColor
+        backgroundStackView.backgroundColor = .systemGray5
+    }
+    
+    // MARK: - Methods
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        dismiss(animated: false)
+    }
+    
+    @IBAction func homeSettingButtonAction(_ sender: Any) {
+        dismiss(animated: false)
+    }
+    
+    @IBAction func backupButtonAction(_ sender: Any) {
+        // Set iCloudDocsURL Here & Do Nil Check
+        if let iCloudDocsURL = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("Documents") {
+            // Make albums' Nost file
+            let realm = try! Realm()
+            var localNostURL = [URL]()
+            var iCloudNostURL = [URL]()
+            let albumCoverInfos = realm.objects(albumCover.self)
+            if albumCoverInfos.isEmpty == true {
+                // Alert
+                // Notice Alert
+                let alert = UIAlertController(title: "저장할 앨범이 없습니다", message: "최소 한 개 이상의 앨범을 생성 후 백업을 진행해주세요", preferredStyle: .alert)
+                let okAction = UIAlertAction(title: "확인", style: .default) { action in
+                    self.dismiss(animated: false) {
+                        self.dismiss(animated: false)
+                    }
+                }
+                alert.addAction(okAction)
+                present(alert, animated: true)
+                return
+            } else {
+                // Check File Path Exist Or Not
+                if !FileManager.default.fileExists(atPath: iCloudDocsURL.path, isDirectory: nil) {
+                    // Case File Path Doesn't Exist, Make Directory Here
+                    try? FileManager.default.createDirectory(at: iCloudDocsURL, withIntermediateDirectories: true, attributes: nil)
+                    print("DATA BACK UP :: CREATE iCLOUD DIRECTORY")
+                }
+                // BackUp
+                do {
+                    let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
+                    var message = String()
+                    if !contents.isEmpty {
+                        var Datas = [String]()
+                        for content in contents {
+                            Datas.append("앨범 명: \(content.replacingOccurrences(of: ".nost", with: ""))")
+                        }
+                        message = "기존 백업 데이터가 존재합니다! \n백업 진행 시, 이전 백업 데이터가 삭제되고 현재 앨범 정보가 저장됩니다.\n\n[이전 백업 데이터]\n\(Datas.joined(separator: "\n"))"
+                    } else {
+                        message = "이전 백업 데이터가 존재하지 않습니다."
+                    }
+                    let alert = UIAlertController(title: "백업", message: message, preferredStyle: .alert)
+                    let okAction = UIAlertAction(title: "확인", style: .default) { action in
+                        for albumCoverInfo in albumCoverInfos {
+                            if let newNostURL = zipAlbumDirectory(AlbumCoverName: albumCoverInfo.albumName) {
+                                localNostURL.append(newNostURL)
+                                iCloudNostURL.append(iCloudDocsURL.appendingPathComponent("\(albumCoverInfo.albumName).nost"))
+                            } else {
+                                // Alert or Error
+                                print("FileManager Error :: Cannot Find Document Directory Path in zipAlbumDirectory")
+                                return
+                            }
+                        }
+                        
+                        // 기존에 백업된 정보 전부 삭제
+                        do {
+                            let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
+                            for content in contents {
+                                do {
+                                    try FileManager.default.removeItem(at: iCloudDocsURL.appendingPathComponent(content))
+                                } catch {
+                                    print("ERROR :: iCloud remove error")
+                                }
+                            }
+                        } catch {
+                            print("ERROR :: FileManager Bring iCloud Document Path Error")
+                        }
+                        
+                        for index in 0...localNostURL.count - 1 {
+                            do {
+                                // Copy Local Directory File Contents To iCloud Driver
+                                try FileManager.default.copyItem(at: localNostURL[index], to: iCloudNostURL[index])
+                                // Delete Local Nost File
+                                try FileManager.default.removeItem(at: localNostURL[index])
+                                print("DATA BACK UP :: UPLOAD SUCCESS TO iCLOUD DRIVER")
+                            } catch let error as NSError {
+                                // Handling Exception Here When You Developing
+                                print("DATA BACK UP :: UPLOAD FAIL TO iCLOUD DRIVER \(error) ")
+                            }
+                        }
+                        
+                        let alert = UIAlertController(title: "백업 완료", message: "백업이 완료되었습니다.👻", preferredStyle: .alert)
+                        let okAction = UIAlertAction(title: "확인", style: .default) { action in
+                            self.dismiss(animated: false)
+                        }
+                        alert.addAction(okAction)
+                        self.present(alert, animated: true)
+                    }
+                    let cancleAction = UIAlertAction(title: "취소", style: .default) { action in
+                        alert.dismiss(animated: false)
+                    }
+                    alert.addAction(okAction)
+                    alert.addAction(cancleAction)
+                    present(alert, animated: false)
+                } catch {
+                    print("ERROR :: FileManager contentsOfDirectory")
+                }
+            }
+        } else {
+            // Notice Alert
+            let alert = UIAlertController(title: "iCloud 연결이 필요합니다", message: "\n설정 - Apple ID - iCloud - 모두 보기 - NostelgiAlbum - 허용 ", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "확인", style: .default) { action in
+                alert.dismiss(animated: false)
+            }
+            alert.addAction(okAction)
+            present(alert, animated: true)
+        }
+    }
+    
+    @IBAction func recoverButtonAction(_ sender: Any) {
+        var AlbumDatas = [String]()
+        
+        if let iCloudDocsURL = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("Documents") {
+            // Success
+            // Notice Alert
+            do {
+                let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
+                if contents.isEmpty {
+                    let alert = UIAlertController(title: "백업 파일이 존재하지 않습니다", message: nil, preferredStyle: .alert)
+                    let okAction = UIAlertAction(title: "확인", style: .default) { action in
+                        alert.dismiss(animated: false)
+                    }
+                    alert.addAction(okAction)
+                    present(alert, animated: false)
+                    return
+                } else {
+                    AlbumDatas = contents
+                }
+            } catch {
+                print("ERROR :: FileManager contentsOfDirectory")
+            }
+        } else {
+            // Failed
+            // Notice Alert
+            let alert = UIAlertController(title: "iCloud 연결이 필요합니다", message: "\n설정 - Apple ID - iCloud - 모두 보기 - NostelgiAlbum - 허용 ", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "확인", style: .default) { action in
+                alert.dismiss(animated: false)
+            }
+            alert.addAction(okAction)
+            present(alert, animated: true)
+            return
+        }
+        
+        let alert = UIAlertController(title: "경고", message: "복원을 진행할 경우 \n현재 생성된 앨범 정보가 모두 삭제됩니다", preferredStyle: .alert)
+        let cancleAction = UIAlertAction(title: "취소", style: .default) { action in
+            alert.dismiss(animated: false)
+        }
+        let okAction = UIAlertAction(title: "확인", style: .default) { action in
+            var Datas = [String]()
+            for AlbumData in AlbumDatas {
+                Datas.append("앨범 명: \(AlbumData.replacingOccurrences(of: ".nost", with: ""))")
+            }
+            let message = "[백업 데이터]\n\(Datas.joined(separator: "\n"))"
+            
+            let alert = UIAlertController(title: "복원", message: "현재 생성된 앨범 정보를 삭제하고 복원을 진행하시겠습니까?\n(복원 완료 시, 어플이 종료됩니다.)\n\n\(message)", preferredStyle: .alert)
+            let cancleAction = UIAlertAction(title: "취소", style: .default) { action in
+                alert.dismiss(animated: false)
+            }
+            let confirmAction = UIAlertAction(title: "확인", style: .default) { action in
+                if let iCloudDocsURL = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("Documents") {
+                    // 기존 정보 삭제
+                    // Document 정보 삭제
+                    guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+                    do {
+                        let contents = try FileManager.default.contentsOfDirectory(atPath: documentDirectory.path)
+                        for content in contents {
+                            if !content.hasPrefix("default") && !content.hasSuffix("Inbox") {
+                                print(content)
+                                do {
+                                    try FileManager.default.removeItem(at: documentDirectory.appendingPathComponent(content))
+                                } catch {
+                                    print("ERROR :: FileManager remove error")
+                                }
+                            }
+                        }
+                    } catch {
+                        print("ERROR :: FileManager Bring Document Path Error")
+                    }
+
+                    // RealmDB 정보 삭제
+                    let realm = try! Realm()
+                    let albumCover = realm.objects(albumCover.self)
+                    let album = realm.objects(album.self)
+                    let albumsInfo = realm.objects(albumsInfo.self)
+
+                    for albumCoverData in albumCover {
+                        do {
+                            try realm.write {
+                                realm.delete(albumCoverData)
+                            }
+                        } catch {
+                            print("ERROR :: Cannot delete albumCover data in realmDB")
+                        }
+                    }
+                    for albumData in album {
+                        do {
+                            try realm.write {
+                                realm.delete(albumData)
+                            }
+                        } catch {
+                            print("ERROR :: Cannot delete album data in realmDB")
+                        }
+                    }
+                    for albumsInfoData in albumsInfo {
+                        do {
+                            try realm.write {
+                                realm.delete(albumsInfoData)
+                            }
+                        } catch {
+                            print("ERROR :: Cannot delete albumsInfo data in realmDB")
+                        }
+                    }
+
+                    // unzip & import data
+                    do {
+                        let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
+                        print(contents)
+                        for content in contents {
+                            if content.hasSuffix(".nost") {
+                                let albumCoverName = content.replacingOccurrences(of: ".nost", with: "")
+                                let shareFilePath = iCloudDocsURL.appendingPathComponent(content)
+                                unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: shareFilePath)
+                                importAlbumInfo(albumCoverName: albumCoverName, useForShare: false)
+                            }
+                        }
+                        print("SUCESS :: Complete Recover!")
+                        UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            exit(0)
+                        }
+                    } catch let error as NSError {
+                        // Handling Exception Here When You Developing
+                        print("TEST Error :: UPLOAD FAIL TO iCLOUD DRIVER \(error)")
+                    }
+                }
+            }
+            alert.addAction(confirmAction)
+            alert.addAction(cancleAction)
+            self.present(alert, animated: true)
+        }
+        alert.addAction(okAction)
+        alert.addAction(cancleAction)
+        present(alert, animated: true)
+    }
+}

--- a/NostelgiAlbum/HomeScreenViewController/HomeScreenCollectionViewCell.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeScreenCollectionViewCell.swift
@@ -1,8 +1,9 @@
 import UIKit
+import RealmSwift
 
 class HomeScreenCollectionViewCell: UICollectionViewCell {
-    
     // MARK: - Properties
+    let realm = try! Realm()
     @IBOutlet weak var firstButton: UIButton!
     @IBOutlet weak var firstButtonTitle: UILabel!
     @IBOutlet weak var secondButton: UIButton!

--- a/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController+CollectionView.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController+CollectionView.swift
@@ -20,7 +20,7 @@ extension HomeScreenViewController: UICollectionViewDataSource{
         // ButtomLabel's backGroundColor
         cell.bottomLabel.backgroundColor = UIColor(red: 0.00, green: 0.00, blue: 0.00, alpha: 1.00)
         // Cell's backGroundColor
-        cell.backgroundColor = UIColor(red: 0.80, green: 0.82, blue: 0.93, alpha: 1.00)
+        cell.setThemeColor()
         
         // Number of Cell that should be printed in CollectionView (data.count + 1[Empty Space])
         let cover_num = realm.objects(albumCover.self).count + 1

--- a/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController.swift
+++ b/NostelgiAlbum/HomeScreenViewController/HomeScreenViewController.swift
@@ -4,8 +4,11 @@ import RealmSwift
 class HomeScreenViewController: UIViewController {
     // MARK: - Properties
     let realm = try! Realm()
+    @IBOutlet weak var topLabel: UILabel!
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var homeSettingButton: UIButton!
+    @IBOutlet weak var homeTitleView: UIView!
+    @IBOutlet weak var NostelgiAlbumLabel: UILabel!
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -13,26 +16,13 @@ class HomeScreenViewController: UIViewController {
         collectionView.dataSource = self
         collectionView.delegate = self
         print("####path",Realm.Configuration.defaultConfiguration.fileURL!)
-        guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
-        do {
-            let contents = try FileManager.default.contentsOfDirectory(atPath: documentDirectory.path)
-            for content in contents {
-                print(content)
-            }
-        } catch {
-            print("error")
-        }
-        if let iCloudDocsURL = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("Documents") {
-            do {
-                let contents = try FileManager.default.contentsOfDirectory(atPath: iCloudDocsURL.path)
-                print(contents)
-                for content in contents {
-                    print(content)
-                }
-            } catch {
-                print("error")
+        if realm.objects(HomeSetting.self).first == nil {
+            let HomeSettingInfo = HomeSetting()
+            try! realm.write {
+                realm.add(HomeSettingInfo)
             }
         }
+        setThemeColor()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/NostelgiAlbum/Model/RealmClassFunc.swift
+++ b/NostelgiAlbum/Model/RealmClassFunc.swift
@@ -1,7 +1,59 @@
 import Foundation
 import RealmSwift
 
-class album : Object{
+class HomeSetting: Object {
+    // MARK: - Properties
+    @objc dynamic var themeColor: String = "blue"
+}
+
+class albumCover: Object {
+    // MARK: - Properties
+    @objc dynamic var id: Int = 0
+    @objc dynamic var coverImageName: String = ""
+    @objc dynamic var albumName: String = ""
+    @objc dynamic var isCustomCover: Bool = false
+    
+    // MARK: - Methods
+    func setcoverImageName(_ db : String){
+        coverImageName = db
+    }
+    
+    func setalbumName(_ db : String){
+        albumName = db
+    }
+    
+    func incrementIndex(){
+        let realm = try! Realm()
+        id = (realm.objects(albumCover.self).max(ofProperty: "id") as Int? ?? 0) + 1
+    }
+}
+
+class albumsInfo: Object {
+    // MARK: - Properties
+    @objc dynamic var id: Int = 0
+    @objc dynamic var numberOfPictures: Int = 0
+    @objc dynamic var dateOfCreation: String = ""
+    
+    // MARK: - Methods
+    func setNumberOfPictures(_ num: Int){
+        let realm = try! Realm()
+        numberOfPictures = realm.objects(album.self).filter("index = \(num)").count
+        print("num : ",numberOfPictures)
+    }
+    
+    func setDateOfCreation(){
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        dateOfCreation = formatter.string(from:Date())
+    }
+    
+    func incrementIndex(){
+        let realm = try! Realm()
+        id = (realm.objects(albumsInfo.self).max(ofProperty: "id") as Int? ?? 0) + 1
+    }
+}
+
+class album: Object {
     // MARK: - Properties
     @objc dynamic var index: Int = 0
     @objc dynamic var perAlbumIndex: Int = 0
@@ -28,53 +80,6 @@ class album : Object{
     
     func setAlbumTitle(_ db : String){
         AlbumTitle = db
-    }
-}
-
-class albumCover : Object{
-    // MARK: - Properties
-    @objc dynamic var id: Int = 0
-    @objc dynamic var coverImageName: String = ""
-    @objc dynamic var albumName: String = ""
-    @objc dynamic var isCustomCover: Bool = false
-    
-    // MARK: - Methods
-    func setcoverImageName(_ db : String){
-        coverImageName = db
-    }
-    
-    func setalbumName(_ db : String){
-        albumName = db
-    }
-    
-    func incrementIndex(){
-        let realm = try! Realm()
-        id = (realm.objects(albumCover.self).max(ofProperty: "id") as Int? ?? 0) + 1
-    }
-}
-
-class albumsInfo : Object{
-    // MARK: - Properties
-    @objc dynamic var id : Int = 0
-    @objc dynamic var numberOfPictures : Int = 0
-    @objc dynamic var dateOfCreation : String = ""
-    
-    // MARK: - Methods
-    func setNumberOfPictures(_ num: Int){
-        let realm = try! Realm()
-        numberOfPictures = realm.objects(album.self).filter("index = \(num)").count
-        print("num : ",numberOfPictures)
-    }
-    
-    func setDateOfCreation(){
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy년 MM월 dd일"
-        dateOfCreation = formatter.string(from:Date())
-    }
-    
-    func incrementIndex(){
-        let realm = try! Realm()
-        id = (realm.objects(albumsInfo.self).max(ofProperty: "id") as Int? ?? 0) + 1
     }
 }
 

--- a/NostelgiAlbum/Supporting Files/Base.lproj/Main.storyboard
+++ b/NostelgiAlbum/Supporting Files/Base.lproj/Main.storyboard
@@ -101,7 +101,9 @@
                     <tabBarItem key="tabBarItem" title="" image="house" catalog="system" id="QbM-ab-c6n"/>
                     <navigationItem key="navigationItem" id="Mkh-YD-rWt"/>
                     <connections>
+                        <outlet property="bottomLabel" destination="2Or-WB-UVj" id="VNX-zu-zgO"/>
                         <outlet property="collectionView" destination="arc-jP-fUr" id="j6z-HW-HbV"/>
+                        <outlet property="topLabel" destination="eQr-3D-tCb" id="zJj-3z-8ML"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OpX-a6-xA8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -154,7 +156,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pDz-rf-7Ho">
-                                        <rect key="frame" x="336" y="21" width="49" height="31"/>
+                                        <rect key="frame" x="338" y="23" width="49" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <state key="normal" title="Button"/>
@@ -196,10 +198,13 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="bodyView" destination="x16-SJ-OeI" id="Kyo-mO-oPY"/>
+                        <outlet property="bottomLabel" destination="fG4-ly-ScL" id="mZE-14-sUx"/>
                         <outlet property="editName" destination="29r-LZ-69x" id="I9p-eu-dMN"/>
                         <outlet property="editPicture" destination="pul-iH-fuh" id="xvV-8b-Emc"/>
                         <outlet property="editText" destination="qd4-6a-Gz8" id="LcF-Vj-Iee"/>
                         <outlet property="saveButton" destination="pDz-rf-7Ho" id="zvr-nF-2d8"/>
+                        <outlet property="topLabel" destination="EBH-OG-RKO" id="aBy-9D-rlj"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UPA-Ui-UH1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -294,10 +299,13 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="bodyView" destination="blZ-Tc-pwX" id="iQb-yb-dy0"/>
+                        <outlet property="bottomLabel" destination="UCN-ev-AEs" id="dsm-wP-dGi"/>
                         <outlet property="picImage" destination="izs-d9-9Yf" id="kmD-oB-3BV"/>
                         <outlet property="picName" destination="DJL-vM-fOY" id="7fy-cP-pgF"/>
                         <outlet property="picText" destination="SO7-SW-9Ff" id="rb2-wK-hJk"/>
                         <outlet property="settingBtn" destination="iX7-Vq-biM" id="WqP-l3-xtn"/>
+                        <outlet property="topLabel" destination="SIF-nT-vqL" id="dNd-Gk-Mjc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8qk-F2-BES" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -1000,7 +1008,7 @@
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="앨범 목록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xym-yq-J0G">
                                         <rect key="frame" x="165" y="12" width="63" height="21"/>
                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
@@ -1108,7 +1116,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="jr6-Sb-uRQ"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" name="BradleyHandITCTT-Bold" family="Bradley Hand" pointSize="34"/>
+                                <fontDescription key="fontDescription" name="BradleyHandITCTT-Bold" family="Bradley Hand" pointSize="30"/>
                                 <color key="textColor" red="0.99215686270000003" green="0.96862745100000003" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -1134,23 +1142,26 @@
                     <tabBarItem key="tabBarItem" title="Item" id="wPT-tZ-0uP"/>
                     <navigationItem key="navigationItem" title="Home" id="3oC-sZ-6tM"/>
                     <connections>
+                        <outlet property="NostelgiAlbumLabel" destination="6L9-YM-yUi" id="CBA-NT-1FZ"/>
                         <outlet property="collectionView" destination="VKf-6f-L40" id="ymV-PE-tdm"/>
                         <outlet property="homeSettingButton" destination="wrN-oa-0Ag" id="ZGU-yb-mfw"/>
+                        <outlet property="homeTitleView" destination="yEZ-va-5m3" id="nOB-Gy-HXy"/>
+                        <outlet property="topLabel" destination="lWX-9f-Spb" id="060-Db-gqG"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="49k-8k-NnS" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="361" y="931"/>
         </scene>
-        <!--Home-->
+        <!--Home iCloud Setting View Controller-->
         <scene sceneID="Fej-Xg-mCz">
             <objects>
-                <viewController storyboardIdentifier="HomeSettingViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="JP0-GQ-iCB" customClass="HomeSettingViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="HomeiCloudSettingViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="JP0-GQ-iCB" userLabel="Home iCloud Setting View Controller" customClass="HomeiCloudSettingViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="koG-3T-3zF">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view alpha="0.84999999999999998" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GaT-Gm-rbx">
+                            <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GaT-Gm-rbx">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
@@ -1180,10 +1191,10 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ob3-OP-dq4">
-                                <rect key="frame" x="298" y="109" width="80" height="180"/>
+                                <rect key="frame" x="233" y="94" width="60" height="140"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZxE-wP-YrH">
-                                        <rect key="frame" x="0.0" y="0.0" width="80" height="62"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="60" height="46"/>
                                         <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="square.and.arrow.up.on.square" catalog="system"/>
@@ -1192,7 +1203,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="백업" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAU-Te-37i">
-                                        <rect key="frame" x="0.0" y="62" width="80" height="15"/>
+                                        <rect key="frame" x="0.0" y="46" width="60" height="15"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="15" id="n46-4g-UPk"/>
                                         </constraints>
@@ -1201,16 +1212,16 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aoR-Qp-3Dd">
-                                        <rect key="frame" x="0.0" y="77" width="80" height="12"/>
+                                        <rect key="frame" x="0.0" y="61" width="60" height="8"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="12" id="Fz9-r8-FAj"/>
+                                            <constraint firstAttribute="height" constant="8" id="Fz9-r8-FAj"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXh-xl-sep">
-                                        <rect key="frame" x="0.0" y="89" width="80" height="2"/>
+                                        <rect key="frame" x="0.0" y="69" width="60" height="2"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="2" id="GmK-ir-HON"/>
@@ -1220,7 +1231,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jKn-ai-pcx">
-                                        <rect key="frame" x="0.0" y="91" width="80" height="62"/>
+                                        <rect key="frame" x="0.0" y="71" width="60" height="46"/>
                                         <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="square.and.arrow.down.on.square" catalog="system"/>
@@ -1229,7 +1240,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="복원" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kMf-Y0-64N">
-                                        <rect key="frame" x="0.0" y="153" width="80" height="15"/>
+                                        <rect key="frame" x="0.0" y="117" width="60" height="15"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="15" id="6kN-Bu-1wX"/>
                                         </constraints>
@@ -1238,9 +1249,9 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q66-MY-dTk">
-                                        <rect key="frame" x="0.0" y="168" width="80" height="12"/>
+                                        <rect key="frame" x="0.0" y="132" width="60" height="8"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="12" id="cVZ-pE-1DP"/>
+                                            <constraint firstAttribute="height" constant="8" id="cVZ-pE-1DP"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
@@ -1249,17 +1260,17 @@
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="80" id="21n-Xk-WNx"/>
-                                    <constraint firstAttribute="height" constant="180" id="Hot-Di-OIG"/>
-                                    <constraint firstAttribute="centerY" secondItem="sAU-Te-37i" secondAttribute="bottom" constant="13" id="VkQ-Ac-qzV"/>
+                                    <constraint firstAttribute="width" constant="60" id="21n-Xk-WNx"/>
+                                    <constraint firstAttribute="height" constant="140" id="Hot-Di-OIG"/>
+                                    <constraint firstAttribute="centerY" secondItem="sAU-Te-37i" secondAttribute="bottom" constant="9" id="VkQ-Ac-qzV"/>
                                 </constraints>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Jgg-FI-pFX"/>
                         <constraints>
                             <constraint firstItem="Jgg-FI-pFX" firstAttribute="trailing" secondItem="eka-6e-u3a" secondAttribute="trailing" id="09r-lF-r98"/>
-                            <constraint firstItem="Ob3-OP-dq4" firstAttribute="trailing" secondItem="0o8-7e-Iqr" secondAttribute="trailing" constant="-5" id="BLB-5F-yBm"/>
-                            <constraint firstItem="Ob3-OP-dq4" firstAttribute="top" secondItem="eka-6e-u3a" secondAttribute="bottom" constant="5" id="OAk-Ul-boS"/>
+                            <constraint firstItem="Ob3-OP-dq4" firstAttribute="trailing" secondItem="0o8-7e-Iqr" secondAttribute="trailing" constant="-90" id="BLB-5F-yBm"/>
+                            <constraint firstItem="Ob3-OP-dq4" firstAttribute="top" secondItem="eka-6e-u3a" secondAttribute="bottom" constant="-10" id="OAk-Ul-boS"/>
                             <constraint firstItem="eka-6e-u3a" firstAttribute="leading" secondItem="Jgg-FI-pFX" secondAttribute="leading" id="Usi-Wq-ZH3"/>
                             <constraint firstItem="eka-6e-u3a" firstAttribute="top" secondItem="Jgg-FI-pFX" secondAttribute="top" id="ZYp-w6-cww"/>
                             <constraint firstAttribute="trailing" secondItem="GaT-Gm-rbx" secondAttribute="trailing" id="rGq-2X-LnQ"/>
@@ -1276,13 +1287,156 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Y0d-in-lCU" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="370.2290076335878" y="257.04225352112678"/>
+            <point key="canvasLocation" x="360" y="-413"/>
+        </scene>
+        <!--Home Setting View Controller-->
+        <scene sceneID="Xjv-o4-acQ">
+            <objects>
+                <viewController storyboardIdentifier="HomeSettingViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="tk2-GR-CMu" userLabel="Home Setting View Controller" customClass="HomeSettingViewController" customModule="NostelgiAlbum" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5dj-20-S0c">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view alpha="0.84999999999999998" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4nF-Px-vWU">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wOg-qN-dcF">
+                                <rect key="frame" x="0.0" y="59" width="393" height="45"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec9-vD-CoV">
+                                        <rect key="frame" x="335.33333333333331" y="0.0" width="47.666666666666686" height="45"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" imagePadding="0.0">
+                                            <imageReference key="image" image="gearshape" catalog="system" variableValue="0.0"/>
+                                            <preferredSymbolConfiguration key="preferredSymbolConfigurationForImage" configurationType="pointSize" pointSize="15" weight="medium"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="settingButtonAction:" destination="tk2-GR-CMu" eventType="touchUpInside" id="zWz-5p-xbP"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="ec9-vD-CoV" firstAttribute="top" secondItem="wOg-qN-dcF" secondAttribute="top" id="NJP-9I-2Ie"/>
+                                    <constraint firstAttribute="height" constant="45" id="P6Q-w0-YOT"/>
+                                    <constraint firstAttribute="trailing" secondItem="ec9-vD-CoV" secondAttribute="trailing" constant="10.000000000000057" id="SSr-vX-3I8"/>
+                                    <constraint firstAttribute="bottom" secondItem="ec9-vD-CoV" secondAttribute="bottom" id="akn-l4-DDs"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PyM-G6-CiU">
+                                <rect key="frame" x="298" y="109" width="80" height="180"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AF9-TQ-1VP">
+                                        <rect key="frame" x="0.0" y="0.0" width="80" height="62"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain">
+                                            <imageReference key="image" image="icloud.and.arrow.up" catalog="system" variableValue="0.0"/>
+                                            <preferredSymbolConfiguration key="preferredSymbolConfigurationForImage" configurationType="pointSize" pointSize="21"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="iCloudButtonAction:" destination="tk2-GR-CMu" eventType="touchUpInside" id="ePt-nP-0Dv"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="iCloud" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kS8-VM-p7o">
+                                        <rect key="frame" x="0.0" y="62" width="80" height="15"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="15" id="Yas-TP-9oo"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9rM-xV-G18">
+                                        <rect key="frame" x="0.0" y="77" width="80" height="12"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="12" id="LMw-e4-7sG"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jX4-k1-cpO">
+                                        <rect key="frame" x="0.0" y="89" width="80" height="2"/>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="2" id="5RL-f0-rFW"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y0B-RT-5NZ">
+                                        <rect key="frame" x="0.0" y="91" width="80" height="62"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain">
+                                            <imageReference key="image" image="scribble.variable" catalog="system"/>
+                                            <preferredSymbolConfiguration key="preferredSymbolConfigurationForImage" configurationType="pointSize" pointSize="20"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="colorSettingButtonAction:" destination="tk2-GR-CMu" eventType="touchUpInside" id="aPS-Ga-QSY"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="색 설정" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hex-V7-HH8">
+                                        <rect key="frame" x="0.0" y="153" width="80" height="15"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="15" id="zSi-hx-2Fe"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2IF-jO-eEn">
+                                        <rect key="frame" x="0.0" y="168" width="80" height="12"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="12" id="Lc2-IA-Qxy"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="80" id="3TM-k0-E5w"/>
+                                    <constraint firstAttribute="centerY" secondItem="kS8-VM-p7o" secondAttribute="bottom" constant="13" id="O1E-WR-37B"/>
+                                    <constraint firstAttribute="height" constant="180" id="Zai-1A-TNd"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="zKl-JX-YmP"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="4nF-Px-vWU" secondAttribute="bottom" id="9XS-7f-mnU"/>
+                            <constraint firstItem="PyM-G6-CiU" firstAttribute="trailing" secondItem="ec9-vD-CoV" secondAttribute="trailing" constant="-5" id="KVR-qF-xYH"/>
+                            <constraint firstItem="zKl-JX-YmP" firstAttribute="trailing" secondItem="wOg-qN-dcF" secondAttribute="trailing" id="LUJ-2N-LO0"/>
+                            <constraint firstItem="4nF-Px-vWU" firstAttribute="leading" secondItem="5dj-20-S0c" secondAttribute="leading" id="Sx9-R8-RlO"/>
+                            <constraint firstAttribute="trailing" secondItem="4nF-Px-vWU" secondAttribute="trailing" id="UWh-J2-rO9"/>
+                            <constraint firstItem="4nF-Px-vWU" firstAttribute="top" secondItem="5dj-20-S0c" secondAttribute="top" id="Ugr-OO-yut"/>
+                            <constraint firstItem="wOg-qN-dcF" firstAttribute="top" secondItem="zKl-JX-YmP" secondAttribute="top" id="a2F-nq-uWO"/>
+                            <constraint firstItem="PyM-G6-CiU" firstAttribute="top" secondItem="wOg-qN-dcF" secondAttribute="bottom" constant="5" id="gfc-h2-hq6"/>
+                            <constraint firstItem="wOg-qN-dcF" firstAttribute="leading" secondItem="zKl-JX-YmP" secondAttribute="leading" id="yqV-yn-p1Q"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Item" id="85H-GL-H96"/>
+                    <navigationItem key="navigationItem" title="Home" id="XMa-JX-sHM"/>
+                    <connections>
+                        <outlet property="backgroundStackView" destination="PyM-G6-CiU" id="0LO-Sy-N4Z"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hCc-Qj-WJh" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="360" y="266"/>
         </scene>
     </scenes>
     <resources>
         <image name="chevron.left" catalog="system" width="97" height="128"/>
         <image name="gearshape" catalog="system" width="128" height="123"/>
         <image name="house" catalog="system" width="128" height="104"/>
+        <image name="icloud.and.arrow.up" catalog="system" width="128" height="108"/>
+        <image name="scribble.variable" catalog="system" width="128" height="119"/>
         <image name="square.and.arrow.down.on.square" catalog="system" width="122" height="128"/>
         <image name="square.and.arrow.up.on.square" catalog="system" width="119" height="128"/>
         <systemColor name="labelColor">

--- a/NostelgiAlbum/ThemeFunc/ThemeColorFunc.swift
+++ b/NostelgiAlbum/ThemeFunc/ThemeColorFunc.swift
@@ -1,0 +1,137 @@
+import UIKit
+
+extension HomeScreenViewController {
+    func setThemeColor() {
+        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+            view.backgroundColor = ThemeColorSet["mainColor"]
+            NostelgiAlbumLabel.backgroundColor = ThemeColorSet["mainColor"]
+            homeTitleView.backgroundColor = ThemeColorSet["mainColor"]
+            collectionView.backgroundColor = ThemeColorSet["subColor_1"]
+            topLabel.backgroundColor = ThemeColorSet["subColor_2"]
+        } else {
+            return
+        }
+    }
+}
+
+extension HomeScreenCollectionViewCell {
+    func setThemeColor() {
+        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+            self.backgroundColor = ThemeColorSet["subColor_1"]
+            self.bottomLabel.backgroundColor = ThemeColorSet["subColor_2"]
+            self.firstButton.backgroundColor = ThemeColorSet["subColor_3"]
+            self.secondButton.backgroundColor = ThemeColorSet["subColor_3"]
+        } else {
+            return
+        }
+    }
+}
+
+extension AlbumScreenViewController {
+    func setThemeColor() {
+        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+            self.view.backgroundColor = ThemeColorSet["mainColor"]
+            self.navigationController?.navigationBar.backgroundColor = ThemeColorSet["mainColor"]
+            self.navigationController?.toolbar.backgroundColor = ThemeColorSet["mainColor"]
+            collectionView.backgroundColor = ThemeColorSet["subColor_1"]
+            topLabel.backgroundColor = ThemeColorSet["subColor_2"]
+            bottomLabel.backgroundColor = ThemeColorSet["subColor_2"]
+        } else {
+            return
+        }
+    }
+}
+
+extension AlbumScreenCollectionViewCell {
+    func setThemeColor() {
+        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+            self.backgroundColor = ThemeColorSet["subColor_1"]
+            self.pictureImgButton?.backgroundColor = ThemeColorSet["subColor_3"]
+        } else {
+            return
+        }
+    }
+}
+
+extension AlbumEditViewController {
+    func setThemeColor() {
+        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+            view.backgroundColor = ThemeColorSet["mainColor"]
+            bodyView.backgroundColor = ThemeColorSet["subColor_1"]
+            topLabel.backgroundColor = ThemeColorSet["subColor_2"]
+            bottomLabel.backgroundColor = ThemeColorSet["subColor_2"]
+            editPicture.backgroundColor = ThemeColorSet["subColor_3"]
+            saveButton.backgroundColor = ThemeColorSet["subColor_4"]
+        } else {
+            return
+        }
+    }
+}
+
+extension AlbumPicViewController {
+    func setThemeColor() {
+        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+            view.backgroundColor = ThemeColorSet["mainColor"]
+            bodyView.backgroundColor = ThemeColorSet["subColor_1"]
+            topLabel.backgroundColor = ThemeColorSet["subColor_2"]
+            bottomLabel.backgroundColor = ThemeColorSet["subColor_2"]
+            picImage.backgroundColor = ThemeColorSet["subColor_3"]
+            settingBtn.tintColor = ThemeColorSet["mainColor"]
+        } else {
+            return
+        }
+    }
+}
+
+extension ImageViewController {
+    func setThemeColor() {
+        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+            scrollView.backgroundColor = ThemeColorSet["subColor_1"]
+            closeButton.tintColor = ThemeColorSet["mainColor"]
+        } else {
+            return
+        }
+    }
+}
+
+extension InfoTableViewController {
+    func setThemeColor() {
+        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+            view.backgroundColor = ThemeColorSet["subColor_1"]
+            tableView.backgroundColor = ThemeColorSet["subColor_1"]
+        } else {
+            return
+        }
+    }
+}
+
+extension InfoTableCell {
+//    func setThemeColor() {
+//        let HomeSettingInfo = realm.objects(HomeSetting.self).first!
+//        if let ThemeColorSet = getColorSet(color: HomeSettingInfo.themeColor) {
+//            self.backgroundColor = ThemeColorSet["subColor_1"]
+//        } else {
+//            return
+//        }
+//    }
+}
+
+func getColorSet(color: String) -> [String: UIColor]? {
+    let ThemeColorSet = ThemeColorSet()
+    var colorSet: [String: UIColor]? = nil
+    switch color {
+    case "blue": colorSet = ThemeColorSet.blue
+    case "brown": colorSet = ThemeColorSet.brown
+    case "green": colorSet = ThemeColorSet.green
+    default: print("error occur")
+    }
+    return colorSet
+}

--- a/NostelgiAlbum/ThemeFunc/ThemeColorSet.swift
+++ b/NostelgiAlbum/ThemeFunc/ThemeColorSet.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+struct ThemeColorSet {
+    let blue: [String: UIColor] = [
+        "mainColor": UIColor(red: 0.27, green: 0.29, blue: 0.45, alpha: 1.00),
+        "subColor_1": UIColor(red: 0.80, green: 0.82, blue: 0.95, alpha: 1.00),
+        "subColor_2": UIColor(red: 0.19, green: 0.21, blue: 0.37, alpha: 1.00),
+        "subColor_3": UIColor(red: 0.67, green: 0.69, blue: 0.85, alpha: 0.60),
+        "subColor_4": UIColor(red: 0.42, green: 0.44, blue: 0.75, alpha: 0.60)
+    ]
+    let brown: [String: UIColor] = [
+        "mainColor": UIColor(red: 0.42, green: 0.32, blue: 0.32, alpha: 1.00),
+        "subColor_1": UIColor(red: 0.79, green: 0.71, blue: 0.71, alpha: 1.00),
+        "subColor_2": UIColor(red: 0.27, green: 0.18, blue: 0.18, alpha: 1.00),
+        "subColor_3": UIColor(red: 0.67, green: 0.56, blue: 0.57, alpha: 0.60),
+        "subColor_4": UIColor(red: 0.52, green: 0.41, blue: 0.42, alpha: 0.60)
+    ]
+    let green: [String: UIColor] = [
+        "mainColor": UIColor(red: 0.33, green: 0.44, blue: 0.45, alpha: 1.00),
+        "subColor_1": UIColor(red: 0.94, green: 0.96, blue: 0.96, alpha: 1.00),
+        "subColor_2": UIColor(red: 0.29, green: 0.40, blue: 0.41, alpha: 1.00),
+        "subColor_3": UIColor(red: 0.85, green: 0.89, blue: 0.90, alpha: 1.00),
+        "subColor_4": UIColor(red: 0.70, green: 0.79, blue: 0.75, alpha: 1.00)
+    ]
+}


### PR DESCRIPTION
## 작성 내용
### Add RealmDB HomeSetting object
1. HomeScreenView의 Setting Button을 탭하여 나오는 모달에 있는 Color 버튼에서 테마 색상을 지정하면 RealmDB에 해당 색상 정보를 저장하는 객체이다.

### HomeScreen SettingButton : Add Theme Color Button
1. 버튼을 누르면 지정할 수 있는 테마 색상 Alert Present
2. 색상을 선택하면 HomeSetting object에 해당 색상 정보가 업데이트 됨
3. 그 후, RealmDB에서 업데이트 된 색상을 불러와 View를 다시 Redraw 하도록 함

> UIView는 backgroundColor 프로퍼티를 업데이트, CollectionView는 CollectionView와 Cell의 색상을 전부 변경해준 뒤 reloadData() func을 사용하여 Redraw를 진행하였다.

### Theme Color Func Folder
1. ThemeColorSet.Swift 파일은 색상 정보들을 모아놓은 파일

> mainColor: HomeScreenView의 view, NostelgiAlbum Label backgroundColor 색상
> subColor_1: HomeScreenView의 CollectionViewCell backgroundColor 색상
> subColor_2: HomeScreenView의 Top Label, Bottom Label backgroundColor 색상
> subColor_3: HomeScreenView의 Empty Button backgroundColor 색상
> subColor_4: AlbumScreenEditView의 `저장`버튼 색상
>> 위의 5가지 색상으로 나머지 View들의 색상도 지정하였다.

2. ThemeColorFunc.Swift 파일은 View들의 색상을 HomeSetting object의 색상 값에 맞게 색상을 변경하는 코드를 모아놓은 파일이다.

> HomeScreenViewController, HomeScreenCollectionViewCell
> AlbumScreenViewController, AlbumScreenCollectionViewCell, AlbumEditViewController, AlbumPicViewController, ImageViewController
> InfoTableViewController

## 특이사항
1. ShareView, SettingView, SearchView에 대해서는 아직 테마 색상이 적용되지 않음
2. BackUp, Recovery Func을 수행하는 경우 HomeSetting Object에 관련한 정보를 BackUp 시에 저장하고, Recovery 시에 삭제 후 이전의 Setting 값을 불러오는 동작은 처리하지 않음 `논의필`
-> 어떤 방식을 채택해도 동작하도록 설계되어 있음
