### PR TITLE
[2023/05/12]-Discard SceneDelegate && Fix kakaotalk share file error/chopmozzi

### DIFF
--- a/NostelgiAlbum.xcodeproj/project.pbxproj
+++ b/NostelgiAlbum.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		8092C3A3298CE6F0007FFEF3 /* HomeEditViewController+ButtonAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092C3A2298CE6F0007FFEF3 /* HomeEditViewController+ButtonAction.swift */; };
 		8092C3A5298CF1AA007FFEF3 /* CollectionView+ButtonAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092C3A4298CF1AA007FFEF3 /* CollectionView+ButtonAction.swift */; };
 		8094CA2428EDC65500E70F76 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8094CA2328EDC65500E70F76 /* AppDelegate.swift */; };
-		8094CA2628EDC65500E70F76 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8094CA2528EDC65500E70F76 /* SceneDelegate.swift */; };
 		8094CA2B28EDC65500E70F76 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8094CA2928EDC65500E70F76 /* Main.storyboard */; };
 		8094CA2D28EDC65900E70F76 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8094CA2C28EDC65900E70F76 /* Assets.xcassets */; };
 		8094CA3028EDC65900E70F76 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8094CA2E28EDC65900E70F76 /* LaunchScreen.storyboard */; };
@@ -117,7 +116,6 @@
 		8092C3A4298CF1AA007FFEF3 /* CollectionView+ButtonAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionView+ButtonAction.swift"; sourceTree = "<group>"; };
 		8094CA2028EDC65500E70F76 /* NostelgiAlbum.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NostelgiAlbum.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8094CA2328EDC65500E70F76 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		8094CA2528EDC65500E70F76 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		8094CA2A28EDC65500E70F76 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8094CA2C28EDC65900E70F76 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8094CA2F28EDC65900E70F76 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -287,7 +285,6 @@
 				8094CA2928EDC65500E70F76 /* Main.storyboard */,
 				8094CA2E28EDC65900E70F76 /* LaunchScreen.storyboard */,
 				8094CA2328EDC65500E70F76 /* AppDelegate.swift */,
-				8094CA2528EDC65500E70F76 /* SceneDelegate.swift */,
 				8094CA2C28EDC65900E70F76 /* Assets.xcassets */,
 				80D580F329FBFEDD00EF65C9 /* Fonts */,
 			);
@@ -751,7 +748,6 @@
 				8320291F295EA8E2001709E9 /* AlbumEditViewController.swift in Sources */,
 				8092C3A3298CE6F0007FFEF3 /* HomeEditViewController+ButtonAction.swift in Sources */,
 				83C615F629994CE30018BBAF /* ToolBarButtonAction.swift in Sources */,
-				8094CA2628EDC65500E70F76 /* SceneDelegate.swift in Sources */,
 				807A193C29312CEF00BC434B /* RealmClassFunc.swift in Sources */,
 				83E5D2B629E80410001C7DE0 /* PageCells.swift in Sources */,
 				8080200E29E18B9700CECCB8 /* InfoViewController.swift in Sources */,
@@ -934,7 +930,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8A6XY8WY2J;
+				DEVELOPMENT_TEAM = N7AA7Y5KM6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NostelgiAlbum/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Please allow to use Camera";
@@ -950,7 +946,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.App-in-App-le.NostelgiAlbum";
+				PRODUCT_BUNDLE_IDENTIFIER = com.chopmozzi.NostelgiAlbum;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -969,7 +965,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8A6XY8WY2J;
+				DEVELOPMENT_TEAM = N7AA7Y5KM6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NostelgiAlbum/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Please allow to use Camera";
@@ -985,7 +981,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.App-in-App-le.NostelgiAlbum";
+				PRODUCT_BUNDLE_IDENTIFIER = com.chopmozzi.NostelgiAlbum;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/NostelgiAlbum/AlbumScreenViewController/ToolBarController/AlbumRenameViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/ToolBarController/AlbumRenameViewController.swift
@@ -24,9 +24,8 @@ class AlbumRenameViewController: UIViewController {
         if albumTextField.text == "" {
             print("비어있습니다.")
         } else {
-            shareVC.albumCoverName = albumTextField.text
-            shareVC.editTitle.text = albumTextField.text
             shareVC.loadingAlbumInfo()
+            shareVC.albumName.text = albumTextField.text
             self.dismiss(animated: true)
         }
     }

--- a/NostelgiAlbum/AlbumScreenViewController/ToolBarController/ShareFunc.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/ToolBarController/ShareFunc.swift
@@ -37,12 +37,8 @@ func zipAlbumDirectory(AlbumCoverName: String) throws -> URL? {
             }
             do {
                 //zip -> nost write
-                if var data = try? Data(contentsOf: zipFilePath) {
+                if let data = try? Data(contentsOf: zipFilePath) {
                     let newURL = URL(filePath: nostURL.path)
-                    let stringToAdd = "@"
-                    let stringData = stringToAdd.data(using: .utf8)
-                    data.append(stringData!)
-                    
                     try? data.write(to: newURL)
                     try FileManager.default.removeItem(at: zipFilePath)
                 } else {
@@ -157,16 +153,6 @@ func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL) throws {
     // unzip한 파일들 저장할 디렉토리 생성
     do {
         let data = try Data(contentsOf: shareFilePath)
-        let lastByte = data.last
-//        let lastByte = data.suffix(1)
-        if let lastByte = lastByte {
-            if lastByte == UInt8(ascii: "@") {
-                print("lastByte: \(lastByte)")
-            }
-            print("lastByte: \(lastByte)")
-        }
-//        print("lasbyte: \(lastByte)")
-        print("중간 지점")
         try data.write(to: zipURL)
         try Zip.unzipFile(zipURL, destination: zipURL.deletingPathExtension(), overwrite: true, password: nil)
         try changeIfModifyName(albumCoverName: AlbumCoverName)

--- a/NostelgiAlbum/AlbumScreenViewController/ToolBarController/ShareFunc.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/ToolBarController/ShareFunc.swift
@@ -37,8 +37,12 @@ func zipAlbumDirectory(AlbumCoverName: String) throws -> URL? {
             }
             do {
                 //zip -> nost write
-                if let data = try? Data(contentsOf: zipFilePath) {
+                if var data = try? Data(contentsOf: zipFilePath) {
                     let newURL = URL(filePath: nostURL.path)
+                    let stringToAdd = "@"
+                    let stringData = stringToAdd.data(using: .utf8)
+                    data.append(stringData!)
+                    
                     try? data.write(to: newURL)
                     try FileManager.default.removeItem(at: zipFilePath)
                 } else {
@@ -78,12 +82,12 @@ func exportAlbumInfo(coverData: String) throws {
     arrCoverInfo.append("\(albumCoverData.first!.id)")
     arrCoverInfo.append("\(albumCoverData.first!.coverImageName)")
     arrCoverInfo.append("\(albumCoverData.first!.isCustomCover)")
-    arrCoverInfo.append("\(albumCoverData.first!.albumName)")
     
     // albumData
     for album in albumData {
         arrImageText.append("\(album.ImageText)")
         arrImageName.append("\(album.ImageName)")
+        print("chop: \(album)")
     }
     
     // albumInfoData
@@ -153,6 +157,16 @@ func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL) throws {
     // unzip한 파일들 저장할 디렉토리 생성
     do {
         let data = try Data(contentsOf: shareFilePath)
+        let lastByte = data.last
+//        let lastByte = data.suffix(1)
+        if let lastByte = lastByte {
+            if lastByte == UInt8(ascii: "@") {
+                print("lastByte: \(lastByte)")
+            }
+            print("lastByte: \(lastByte)")
+        }
+//        print("lasbyte: \(lastByte)")
+        print("중간 지점")
         try data.write(to: zipURL)
         try Zip.unzipFile(zipURL, destination: zipURL.deletingPathExtension(), overwrite: true, password: nil)
         try changeIfModifyName(albumCoverName: AlbumCoverName)
@@ -224,7 +238,7 @@ func importAlbumInfo(albumCoverName: String, useForShare: Bool) throws {
     }
     shareAlbumCover.coverImageName = arrCoverInfo[1]
     shareAlbumCover.isCustomCover = Bool(arrCoverInfo[2])!
-    shareAlbumCover.albumName = arrCoverInfo[3]
+    shareAlbumCover.albumName = albumCoverName
     
     
     let shareAlbumInfo = albumsInfo()

--- a/NostelgiAlbum/AlbumScreenViewController/ToolBarController/ShareViewController.swift
+++ b/NostelgiAlbum/AlbumScreenViewController/ToolBarController/ShareViewController.swift
@@ -48,6 +48,7 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
                 return
             }
             do {
+                albumCoverName = albumName.text
                 //realm에 공유받은 album정보 write
                 try importAlbumInfo(albumCoverName: albumCoverName, useForShare: true)
             } catch let error {

--- a/NostelgiAlbum/Info.plist
+++ b/NostelgiAlbum/Info.plist
@@ -17,6 +17,34 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string></string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakaoba34b359e20b51a415f50d09ccd869f2</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.AppInApple.nost</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>NostelgiAlbum</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaopassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>NSUbiquitousContainers</key>
 	<dict>
 		<key>iCloud.com.App-in-App-le.NostelgiAlbum</key>
@@ -38,25 +66,6 @@
 		<string>PyeongChangPeace-Bold.otf</string>
 		<string>PyeongChangPeace-Light.otf</string>
 	</array>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/NostelgiAlbum/Info.plist
+++ b/NostelgiAlbum/Info.plist
@@ -17,34 +17,6 @@
 			</array>
 		</dict>
 	</array>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLName</key>
-			<string></string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>kakaoba34b359e20b51a415f50d09ccd869f2</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLName</key>
-			<string>com.AppInApple.nost</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>NostelgiAlbum</string>
-			</array>
-		</dict>
-	</array>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>kakaopassauth</string>
-		<string>kakaolink</string>
-	</array>
 	<key>NSUbiquitousContainers</key>
 	<dict>
 		<key>iCloud.com.App-in-App-le.NostelgiAlbum</key>

--- a/NostelgiAlbum/Supporting Files/AppDelegate.swift
+++ b/NostelgiAlbum/Supporting Files/AppDelegate.swift
@@ -1,27 +1,43 @@
 import UIKit
-
+import os.log
+//import KakaoSDKCommon
+//import KakaoSDKAuth
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
+    var window: UIWindow?
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        print("1")
         nostFileRemove()
+        deleteTmpPicture()
+        // moveItem한 곳을 비우는 지점(강제종료가 돼서 데이터가 남아있다 가정) 1
+//        KakaoSDK.initSDK(appKey: "ba34b359e20b51a415f50d09ccd869f2")
         return true
     }
-
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
+    
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
+        // Inbox가 생성이 되는 지점 2
+        print("chopchopchop")
+        print(url.absoluteString)
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        //Main.storyboard의 HomeScreenViewController객체를 가져옴
+        let vc = storyboard.instantiateViewController(withIdentifier: "HomeScreenViewController")
+        //UINavigationController의 rootViewController를 HomeScreenViewController로 지정
+        let navigationController = UINavigationController(rootViewController: vc)
+        //rootViewControlelr에 객체 값 할당
+        window?.rootViewController = vc
+        window?.rootViewController = navigationController
+        // moveItem을 하는 지점 3
+        if(url.scheme == "file" && url.pathExtension == "nost")
+        {
+            guard let homeScreenViewController = navigationController.viewControllers.first as? HomeScreenViewController else {
+                return false
+            }
+            //HomeScreenViewController의 pushShareView 동작(파일 URL을 같이 넣어줌)
+            homeScreenViewController.pushShareView(path: url)
+        }
+        return true
+        }
     
 
 }

--- a/NostelgiAlbum/Supporting Files/SceneDelegate.swift
+++ b/NostelgiAlbum/Supporting Files/SceneDelegate.swift
@@ -1,4 +1,7 @@
 import UIKit
+import Dispatch
+import os.log
+//import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -7,14 +10,44 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         
+//        if connectionOptions.urlContexts.first?.url != nil {
+//            let urlinfo = connectionOptions.urlContexts.first?.url
+//            os_log("찹모찌")
+//        }
+        os_log("확인용")
         guard let _ = (scene as? UIWindowScene) else { return }
+
+//        if connectionOptions.urlContexts.first?.url != nil {
+//            os_log("왜")
+//            self.scene(scene, openURLContexts: connectionOptions.urlContexts)
+//        } else {
+//            os_log("안돼")
+//        }
+        if connectionOptions.urlContexts.count > 0 {
+            os_log("이거 맞아?")
+        } else {
+            os_log("아닌듯요")
+        }
+//        if(connectionOptions.URLContexts.count > 0){
+//
+//            UIOpenURLContext* urlContext = connectionOptions.URLContexts.anyObject;
+//
+//            // 바로 처리해주면, 또 안되네, 조금 기다렸다가 처리하라고 시키자.
+//            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+//                UIApplication* application = [UIApplication sharedApplication];
+//                [application.delegate application:application openURL:urlContext.URL options:@{}];
+//            });
+//        }
+
     }
     /*
      .nost파일을 통해 앱을 열 때 호출되는 함수
      iOS 13이상 적용
      */
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        os_log("찹모찌2", type: .default)
         nostFileRemove()
+        os_log("찹모찌3", type: .default)
         //Main.storyboard set
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         //Main.storyboard의 HomeScreenViewController객체를 가져옴
@@ -24,14 +57,54 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         //rootViewControlelr에 객체 값 할당
         window?.rootViewController = vc
         window?.rootViewController = navigationController
+        os_log("찹모찌4", type: .default)
+
         //NostelgiAlbum을 여는 경로가 .nost file일 때
-        let url = URLContexts.first?.url
+        var url = URLContexts.first?.url
+        print(url!.path)
+//        print("test",URLContexts)
+        guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+        let testURL = documentDirectory.appendingPathComponent("test.nost")
+        let string = "test"
+        let txtURL = documentDirectory.appendingPathComponent("\(string).txt")
+        print("txtURL",txtURL)
+        do  {
+            try string.write(to: txtURL, atomically: true, encoding: .utf8)
+        } catch let error {
+            print("error")
+            //            os_log("로그확인: \(error.localizedDescription)")
+            let message = "확인 \(error.localizedDescription)"
+            os_log(.error, log: .default, "%@", message)
+        }
+        os_log("찹모찌", type: .default)
+//        do {
+//            try string.write(to: testURL, atomically: true, encoding: .utf8)
+//        } catch {
+//            print("error")
+//        }
+//        do {
+//            try FileManager.default.moveItem(at: url!, to: testURL)
+//            url = testURL
+//        } catch {
+//            print("error")
+//        }
+//
         if(url?.scheme == "file" && url?.pathExtension == "nost")
         {
-            //navigationController.viewControllers.first == HomeScreenViewController
-            guard let homeScreenViewController = navigationController.viewControllers.first as? HomeScreenViewController else { return }
-            //HomeScreenViewController의 pushShareView 동작(파일 URL을 같이 넣어줌)
-            homeScreenViewController.pushShareView(path: url!)
+//            let delay = DispatchTimeInterval.seconds(10)
+//            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                //navigationController.viewControllers.first == HomeScreenViewController
+                guard let homeScreenViewController = navigationController.viewControllers.first as? HomeScreenViewController else {
+//                    do {
+//                        try string.write(to: testURL, atomically: true, encoding: .utf8)
+//                    } catch {
+//                        print("error")
+//                    }
+                    return
+                }
+                //HomeScreenViewController의 pushShareView 동작(파일 URL을 같이 넣어줌)
+                homeScreenViewController.pushShareView(path: url!)
+//            }
         }
 
 


### PR DESCRIPTION
## 작성 내용
카카오톡을 이용해 .nost파일을 주고 받을 시, 파일을 열 때 sceneDelegate에서 URL scheme데이터를 전달 못하는 상황이 발생, 따라서 sceneDelegate에서 동작시키던걸 AppDelegate로 옮기고 sceneDelegate는 삭제하여 문제 해결

ShareViewController의 textField의 값이 AlbumCoverName의 값으로 다시 초기화 안되던 부분 수정

## 특이사항
nil