### PR TITLE
[2023/06/01]-오류해결 및 공유 파일 방식 변경/chopmozzi

### DIFF
--- a/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Search/PageSearch/PageCells.swift
+++ b/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Search/PageSearch/PageCells.swift
@@ -15,6 +15,10 @@ class PageCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        button.isHidden = false
+        button.backgroundColor = UIColor.white
+    }
 }
 
 extension PageCell {

--- a/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Search/PageSearch/PageDelegate+Layout.swift
+++ b/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Search/PageSearch/PageDelegate+Layout.swift
@@ -187,17 +187,16 @@ extension PageSearchViewController: UICollectionViewDataSource {
     }
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PageCell.reuseIdentifier, for: indexPath) as! PageCell
+        cell.button.isHidden = false
         cell.button.setTitle("\(indexPath.item - 1)", for: .normal)
         cell.button.titleLabel?.textColor = .white
         cell.button.pageNum = indexPath.item - 2
         cell.button.indexPath = indexPath
         cell.button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
         cell.index = index
-//        cell.button.layer.cornerRadius = collectionView.bounds.height/24.0
         cell.setFont()
         if indexPath.item < 2 || indexPath.item > pageCount + 2 {
             cell.button.isHidden = true
-            cell.layer.isHidden = true
         } else {
             pageButtonList.append(cell.button)
         }

--- a/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Search/PageSearch/PageSearchViewController.swift
+++ b/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Search/PageSearch/PageSearchViewController.swift
@@ -66,7 +66,7 @@ class PageSearchViewController: UIViewController {
             previousButton = sender.pageNum
             loadPageInfo(btnPageNum: sender.pageNum)
             for i in 0...pageButtonList.count - 1 {
-                if (sender.pageNum ) == i {
+                if (sender.pageNum) == i {
                     setThemeColorButton(pageButtonList[i])
                 } else {
                     pageButtonList[i].backgroundColor = UIColor.white

--- a/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Share/ShareFunc.swift
+++ b/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Share/ShareFunc.swift
@@ -42,7 +42,7 @@ func zipAlbumDirectory(AlbumCoverName: String) throws -> URL? {
             do {
                 //zip -> nost write
                 if var data = try? Data(contentsOf: zipFilePath) {
-                    let stringToCheck = "@"
+                    let stringToCheck = "$"
                     let checkData = stringToCheck.data(using: .utf8)
                     data.append(checkData!)
                     let newURL = URL(filePath: nostURL.path)
@@ -80,7 +80,7 @@ func exportAlbumInfo(coverData: String) throws {
     var arrImageName = [String]()
     var arrImageText = [String]()
     var arrAlbumInfo = [String]()
-    
+    var arrTextCount = [String]()
     // albumCoverData
     arrCoverInfo.append("\(albumCoverData.first!.id)")
     arrCoverInfo.append("\(albumCoverData.first!.coverImageName)")
@@ -91,6 +91,15 @@ func exportAlbumInfo(coverData: String) throws {
         arrImageText.append("\(album.ImageText)")
         arrImageName.append("\(album.ImageName)")
     }
+    for iText in arrImageText {
+        let count = iText.components(separatedBy: "\n")
+        if iText == "" {
+            arrTextCount.append(String(count.count - 1))
+        } else {
+            arrTextCount.append(String(count.count))
+        }
+    }
+    print(arrTextCount)
     
     // albumInfoData
     arrAlbumInfo.append("\(albumInfo.first!.id)")
@@ -98,6 +107,9 @@ func exportAlbumInfo(coverData: String) throws {
     arrAlbumInfo.append(albumInfo.first!.dateOfCreation)
     arrAlbumInfo.append(albumInfo.first!.font)
     arrAlbumInfo.append(String(albumInfo.first!.firstPageSetting))
+    
+    let imageTextTable = arrTextCount.joined(separator: " ")
+    arrImageText.insert(imageTextTable, at: 0)
     
     let albumCoverInfo = arrCoverInfo.joined(separator: "\n")
     let imageNameInfo = arrImageName.joined(separator: "\n")
@@ -152,7 +164,7 @@ func exportAlbumInfo(coverData: String) throws {
     
 }
 
-func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL, deleteShareFile: Bool) throws {
+func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL, checkFileProvider: Bool) throws {
     guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {return}
     // (앨범 이름).zip file을 만들 경로
     let zipURL = documentDirectory.appendingPathComponent("\(AlbumCoverName).zip")
@@ -161,7 +173,7 @@ func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL, deleteShare
         let data = try Data(contentsOf: shareFilePath)
         let checkByte = data.last
         if let checkByte = checkByte {
-            if checkByte == UInt8(ascii: "@") {
+            if checkByte == UInt8(ascii: "$") {
                 print("올바른 파일입니다.")
             } else {
                 throw ErrorMessage.notNost
@@ -174,7 +186,7 @@ func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL, deleteShare
         try FileManager.default.removeItem(at: zipURL)
         //filePath == simulator의 경우 tmp/com....NostelgiAlbum-Inbox
         //device의 경우 Inbox/내 .nost파일
-        if deleteShareFile == true {
+        if checkFileProvider == false {
             try FileManager.default.removeItem(at: shareFilePath)
         }
     } catch let error {
@@ -221,9 +233,25 @@ func importAlbumInfo(albumCoverName: String, useForShare: Bool) throws {
         for name in names {
             arrImageName.append("\(name)")
         }
-        for text in texts {
-            arrImageText.append("\(text)")
+        
+        var textCount = 1
+        let arr = texts.first!.split(separator: " ").map{ Int($0)! }
+        let strArr = texts.map{ String($0) }
+        for i in arr {
+            var str = ""
+            if i > 0 {
+                for check in 1...i {
+                    if check != i {
+                        str.append("\(strArr[textCount])\n")
+                    } else {
+                        str.append("\(strArr[textCount])")
+                    }
+                    textCount += 1
+                }
+            }
+            arrImageText.append("\(str)")
         }
+        
         for info in infos {
             arrAlbumInfo.append("\(info)")
         }

--- a/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Share/ShareFunc.swift
+++ b/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Share/ShareFunc.swift
@@ -99,7 +99,6 @@ func exportAlbumInfo(coverData: String) throws {
             arrTextCount.append(String(count.count))
         }
     }
-    print(arrTextCount)
     
     // albumInfoData
     arrAlbumInfo.append("\(albumInfo.first!.id)")
@@ -164,7 +163,7 @@ func exportAlbumInfo(coverData: String) throws {
     
 }
 
-func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL, checkFileProvider: Bool) throws {
+func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL, deleteShareFile: Bool) throws {
     guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {return}
     // (앨범 이름).zip file을 만들 경로
     let zipURL = documentDirectory.appendingPathComponent("\(AlbumCoverName).zip")
@@ -186,7 +185,7 @@ func unzipAlbumDirectory(AlbumCoverName: String, shareFilePath: URL, checkFilePr
         try FileManager.default.removeItem(at: zipURL)
         //filePath == simulator의 경우 tmp/com....NostelgiAlbum-Inbox
         //device의 경우 Inbox/내 .nost파일
-        if checkFileProvider == false {
+        if deleteShareFile == true {
             try FileManager.default.removeItem(at: shareFilePath)
         }
     } catch let error {

--- a/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Share/ShareViewController.swift
+++ b/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Share/ShareViewController.swift
@@ -15,7 +15,7 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
     var filePath: URL?
     var existedAlbum : Bool!
     var albumCoverName : String!
-    var checkFileProvider : Bool!
+    var deleteShareFile : Bool!
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -47,7 +47,7 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
         //.nost file URL에서 .nost앞 앨범 이름만 따옴
         if !existedAlbum {
             do {
-                try unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: filePath!, checkFileProvider: checkFileProvider)
+                try unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: filePath!, deleteShareFile: deleteShareFile)
             } catch let error {
                 NSErrorHandling_Alert(error: error, vc: self)
                 // MARK: - Document에 저장된 album Directory 삭제
@@ -129,7 +129,7 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
     }
     
     @IBAction func closeInButtonTapped(_ sender: Any) {
-        if !checkFileProvider {
+        if deleteShareFile {
             do{
                 try FileManager.default.removeItem(at: filePath!)
             } catch let error {

--- a/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Share/ShareViewController.swift
+++ b/NostalgiAlbum/AlbumScreenViewController/ToolBarController/Share/ShareViewController.swift
@@ -15,6 +15,7 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
     var filePath: URL?
     var existedAlbum : Bool!
     var albumCoverName : String!
+    var checkFileProvider : Bool!
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -46,7 +47,7 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
         //.nost file URL에서 .nost앞 앨범 이름만 따옴
         if !existedAlbum {
             do {
-                try unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: filePath!, deleteShareFile: true)
+                try unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: filePath!, checkFileProvider: checkFileProvider)
             } catch let error {
                 NSErrorHandling_Alert(error: error, vc: self)
                 // MARK: - Document에 저장된 album Directory 삭제
@@ -128,12 +129,13 @@ class ShareViewController: UIViewController, UIDocumentPickerDelegate {
     }
     
     @IBAction func closeInButtonTapped(_ sender: Any) {
-        do{
-            try FileManager.default.removeItem(at: filePath!)
-        } catch let error {
-            print("NSError Occur :: \(error)")
+        if !checkFileProvider {
+            do{
+                try FileManager.default.removeItem(at: filePath!)
+            } catch let error {
+                print("NSError Occur :: \(error)")
+            }
         }
-        
         self.dismiss(animated: false)
     }
 

--- a/NostalgiAlbum/Function/ErrorHandlingFunc/ErrorHandlingFunc.swift
+++ b/NostalgiAlbum/Function/ErrorHandlingFunc/ErrorHandlingFunc.swift
@@ -68,7 +68,7 @@ func NSErrorHandling_Alert(error: Error, vc: UIViewController) {
         
     case ErrorMessage.notNost:
         titleText = "잘못된 파일"
-        messageText = "잘못된 파일 형식입니다."
+        messageText = "잘못된 파일 형식입니다.\n 앱을 업데이트 후 다시 nost파일을 생성해주세요."
         
     case let nsError as NSError where nsError.domain == "io.realm":
         titleText = "데이터 베이스 오류"

--- a/NostalgiAlbum/HomeScreenViewController/HomeDetailController/HomeiCloudSettingViewController.swift
+++ b/NostalgiAlbum/HomeScreenViewController/HomeDetailController/HomeiCloudSettingViewController.swift
@@ -412,7 +412,7 @@ class HomeiCloudSettingViewController: UIViewController {
                                         let shareFilePath = iCloudDocsURL.appendingPathComponent(content)
                                         do{
                                             // deleteShareFile: false -> 백업 파일은 성공 시 삭제
-                                            try unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: shareFilePath, deleteShareFile: false)
+                                            try unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: shareFilePath, checkFileProvider: true)
                                         } catch let error {
                                             // 디비 정보, 사진 정보, 백업 파일 전부 백업했다가 실패 시 전체 복원
                                             do {

--- a/NostalgiAlbum/HomeScreenViewController/HomeDetailController/HomeiCloudSettingViewController.swift
+++ b/NostalgiAlbum/HomeScreenViewController/HomeDetailController/HomeiCloudSettingViewController.swift
@@ -412,7 +412,7 @@ class HomeiCloudSettingViewController: UIViewController {
                                         let shareFilePath = iCloudDocsURL.appendingPathComponent(content)
                                         do{
                                             // deleteShareFile: false -> 백업 파일은 성공 시 삭제
-                                            try unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: shareFilePath, checkFileProvider: true)
+                                            try unzipAlbumDirectory(AlbumCoverName: albumCoverName, shareFilePath: shareFilePath, deleteShareFile: false)
                                         } catch let error {
                                             // 디비 정보, 사진 정보, 백업 파일 전부 백업했다가 실패 시 전체 복원
                                             do {

--- a/NostalgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
+++ b/NostalgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
@@ -1,12 +1,13 @@
 import UIKit
 
 extension HomeScreenViewController {
-    func pushShareView(path: URL) {
+    func pushShareView(path: URL, checkFileProvider: Bool) {
         // 앨범을 공유 받았을 때, 출력되는 ViewController 생성
         let shareVC = self.storyboard?.instantiateViewController(withIdentifier: "ShareViewController") as! ShareViewController
         // 앨범을 공유 받은 경로 전달
         shareVC.filePath = path
         shareVC.collectionViewInHome = collectionView
+        shareVC.checkFileProvider = checkFileProvider
         // 해당  shareVC를 Present
         shareVC.modalPresentationStyle = .overFullScreen
         self.present(shareVC, animated: false)

--- a/NostalgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
+++ b/NostalgiAlbum/HomeScreenViewController/SharingAlbumPush.swift
@@ -1,13 +1,13 @@
 import UIKit
 
 extension HomeScreenViewController {
-    func pushShareView(path: URL, checkFileProvider: Bool) {
+    func pushShareView(path: URL, deleteShareFile: Bool) {
         // 앨범을 공유 받았을 때, 출력되는 ViewController 생성
         let shareVC = self.storyboard?.instantiateViewController(withIdentifier: "ShareViewController") as! ShareViewController
         // 앨범을 공유 받은 경로 전달
         shareVC.filePath = path
         shareVC.collectionViewInHome = collectionView
-        shareVC.checkFileProvider = checkFileProvider
+        shareVC.checkFileProvider = deleteShareFile
         // 해당  shareVC를 Present
         shareVC.modalPresentationStyle = .overFullScreen
         self.present(shareVC, animated: false)

--- a/NostalgiAlbum/Supporting Files/AppDelegate.swift
+++ b/NostalgiAlbum/Supporting Files/AppDelegate.swift
@@ -57,7 +57,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let checkPath = url.path.split(separator: "/")
             if checkPath.contains("File Provider Storage") {
                 checkFileProvider = true
-                print("urlchopmojji")
             }
             
             if !checkFileProvider {
@@ -79,9 +78,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     NSErrorHandling_Alert(error: error, vc: homeScreenViewController)
                 }
                 //HomeScreenViewController의 pushShareView 동작(파일 URL을 같이 넣어줌)
-                homeScreenViewController.pushShareView(path: extfileURL, checkFileProvider: checkFileProvider)
+                homeScreenViewController.pushShareView(path: extfileURL, deleteShareFile: !checkFileProvider)
             }
-            homeScreenViewController.pushShareView(path: url, checkFileProvider: checkFileProvider)
+            homeScreenViewController.pushShareView(path: url, deleteShareFile: !checkFileProvider)
         }
             return true
         }

--- a/NostalgiAlbum/Supporting Files/AppDelegate.swift
+++ b/NostalgiAlbum/Supporting Files/AppDelegate.swift
@@ -53,25 +53,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 NSErrorHandling_Alert(error: error, vc: homeScreenViewController)
                 return false
             }
-            let extURL = documentDirectory.appendingPathComponent("extTemp")
-            let extfileURL = extURL.appendingPathComponent(url.lastPathComponent)
-            do {
-                if !FileManager.default.fileExists(atPath: extURL.path) {
-                    try FileManager.default.createDirectory(at: extURL, withIntermediateDirectories: true, attributes: nil)
-                }
+            var checkFileProvider = false
+            let checkPath = url.path.split(separator: "/")
+            if checkPath.contains("File Provider Storage") {
+                checkFileProvider = true
+                print("urlchopmojji")
+            }
+            
+            if !checkFileProvider {
+                let extURL = documentDirectory.appendingPathComponent("extTemp")
+                let extfileURL = extURL.appendingPathComponent(url.lastPathComponent)
                 do {
-                    try FileManager.default.moveItem(at: url, to: extfileURL)
+                    if !FileManager.default.fileExists(atPath: extURL.path) {
+                        try FileManager.default.createDirectory(at: extURL, withIntermediateDirectories: true, attributes: nil)
+                    }
+                    do {
+                        try FileManager.default.moveItem(at: url, to: extfileURL)
+                    } catch let error {
+                        print("move error")
+                        print("error:\(error.localizedDescription)")
+                        NSErrorHandling_Alert(error: error, vc: homeScreenViewController)
+                    }
                 } catch let error {
-                    print("move error")
-                    print("error:\(error.localizedDescription)")
+                    print("create dir error")
                     NSErrorHandling_Alert(error: error, vc: homeScreenViewController)
                 }
-            } catch let error {
-                print("create dir error")
-                NSErrorHandling_Alert(error: error, vc: homeScreenViewController)
+                //HomeScreenViewController의 pushShareView 동작(파일 URL을 같이 넣어줌)
+                homeScreenViewController.pushShareView(path: extfileURL, checkFileProvider: checkFileProvider)
             }
-            //HomeScreenViewController의 pushShareView 동작(파일 URL을 같이 넣어줌)
-            homeScreenViewController.pushShareView(path: extfileURL)
+            homeScreenViewController.pushShareView(path: url, checkFileProvider: checkFileProvider)
         }
             return true
         }


### PR DESCRIPTION
## 작성 내용
1. export할 때 ""인 정보는 import할때 구별이 안됨
- imageTextInfo의 첫줄에 각 내용이 몇줄을 사용하는지 테이블을 작성해서 삽입
- ex) 아무런 내용이 없으면 0, 내용은 있는데 “\n”이 없으면 1, 그 외 “\n”개수 +1

2. export할 때 separater \n로 하면 띄어쓰기 들어간 앨범 내용 문제 발생할 듯 함
- 1번과 동일

3. File 에서 공유 받는 파일은 실기기에서 공유가 안받아짐 - `chopmozzi`
- File에서 공유 받는 파일은 카카오톡에서 공유 받는 것과 경로가 다름.
- 카카오톡같은 외부 파일 링크에서 받을 경우 App내의 Sandbox의 tmp에 저장 후 이동하지만 File의 경우 App 바깥의 경로에서 받아옴(File Provider Storage)
- 따라서 경로에 File Provider Storage가 존재할 경우는 File에서 공유 받는 파일
- Bool 변수 추가해서 File에서 공유 받는지 확인 후 File에서 공유 받으면 moveItem을 쓰지 않고 외부 경로를 그대로 사용함.

4. 공유 받은 파일 “취소” 버튼 누르면 삭제 됨 (File 에 nost 파일을 저장한 경우에만 해당 됨)
- 추가한 Bool 변수를 바탕으로 File에서 공유 받으변 삭제 안되도록

5. pageSearchView 버튼 문제 있음 → 페이지 수가 7개 넘어가면 스크롤 할때 부분적으로 안보이거나 색 변경이 적용 안됨
- cell.button.layer = isHidden 이 코드 때문에 생기던 문제 지워줘서 해결함

## 특이사항
업데이트 하면서 공유 파일의 형식이 변경이 되었으므로 이전 버전에서 만들었던 공유 파일은 공유되지 않도록 체크문자("@")를 "$"로 변경함.
이전 버전에서 만들었던 공유파일을 열 시 업데이트 안내 문구 제공
